### PR TITLE
migrations stage/job now use names in constants

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -11,6 +11,8 @@ LAUNCH_INSTANCE_STAGE_NAME = 'launch_instance'
 LAUNCH_INSTANCE_JOB_NAME = 'launch_instance_job'
 RUN_PLAY_STAGE_NAME = "run_play"
 RUN_PLAY_JOB_NAME = "run_play_job"
+APPLY_MIGRATIONS_STAGE = 'apply_migrations'
+APPLY_MIGRATIONS_JOB = 'apply_migrations_job'
 
 # Defaults
 ARTIFACT_PATH = 'target'

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -546,10 +546,10 @@ def generate_run_migrations(pipeline,
         }
     )
 
-    stage = pipeline.ensure_stage('Apply-Migrations')
+    stage = pipeline.ensure_stage(constants.APPLY_MIGRATIONS_STAGE)
     if manual_approval:
         stage.set_has_manual_approval()
-    job = stage.ensure_job('Apply_Migrations_Job')
+    job = stage.ensure_job(constants.APPLY_MIGRATIONS_JOB)
 
     # Check out the requested version of configuration
     tasks.guarantee_configuration_version(job)


### PR DESCRIPTION
@edx/pipeline-team PTAL. Small change to standardize migrations stage/job name.