### PR TITLE
Allow the configuration secure directory to be specified for the play stage

### DIFF
--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -135,6 +135,7 @@ def generate_run_play(pipeline,
                       hipchat_token='',
                       hipchat_room=constants.HIPCHAT_ROOM,
                       manual_approval=False,
+                      config_secure_dir=constants.PRIVATE_CONFIGURATION_LOCAL_DIR,
                       **kwargs):
     """
     TODO: This currently runs from the configuration/playbooks/continuous_delivery/ directory. Need to figure out how to
@@ -212,7 +213,7 @@ def generate_run_play(pipeline,
     artifact_params['src'] = FetchArtifactFile('ansible_inventory')
     job.add_task(FetchArtifactTask(**artifact_params))
 
-    tasks.generate_run_app_playbook(job, constants.PRIVATE_CONFIGURATION_LOCAL_DIR, playbook_with_path, **kwargs)
+    tasks.generate_run_app_playbook(job, config_secure_dir, playbook_with_path, **kwargs)
     return stage
 
 


### PR DESCRIPTION
@doctoryes PTAL. This will allow us to specify the directory of the configuration secure repo to support deployments of the edge, mckinsey, etc environments. 