### PR TITLE
Make ASG rollback pipelines run automatically.

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -19,6 +19,8 @@ MANUAL_VERIFICATION_STAGE_NAME = 'manual_verification'
 MANUAL_VERIFICATION_JOB_NAME = 'manual_verification_job'
 ROLLBACK_ASGS_STAGE_NAME = 'rollback_asgs'
 ROLLBACK_ASGS_JOB_NAME = 'rollback_asgs_job'
+ARMED_STAGE_NAME = 'armed_stage'
+ARMED_JOB_NAME = 'armed_job'
 
 # Tubular configuration
 TUBULAR_SLEEP_WAIT_TIME = '20'

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -939,3 +939,36 @@ def generate_update_index(
         hipchat_room,
         manual_approval
     )
+
+
+def generate_armed_stage(pipeline, stage_name):
+    """
+    Generates a stage that can be used to "arm" a pipeline.
+
+    When using a fan in or fan out GoCD will ensure the consistency of materials used between pipelines. To accomplish
+     this all pipelines must be set to to trigger on success. This stage generates a simple echo statement that can
+     be used to "arm" a pipeline. The stage that follows this must set the manual_approval flag via:
+     set_has_manual_approval()
+
+    Using this pattern allows a pipeline to be be set as automatic, but then pause and wait for input from the user.
+
+    Args:
+        pipeline (gomatic.Pipeline): Pipeline to which to add the run migrations stage.
+        stage_name (str): Name of the stage.
+
+    Returns:
+        gomatic.Stage
+    """
+    armed_stage = pipeline.ensure_stage(stage_name)
+    armed_job = armed_stage.ensure_job(constants.ARMED_JOB_NAME)
+    armed_job.add_task(
+        ExecTask(
+            [
+                '/bin/bash',
+                '-c',
+                'echo Pipeline run number $GO_PIPELINE_COUNTER armed by $GO_TRIGGER_USER'
+            ],
+        )
+    )
+
+    return armed_stage

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -953,7 +953,7 @@ def generate_armed_stage(pipeline, stage_name):
     Using this pattern allows a pipeline to be be set as automatic, but then pause and wait for input from the user.
 
     Args:
-        pipeline (gomatic.Pipeline): Pipeline to which to add the run migrations stage.
+        pipeline (gomatic.Pipeline): Pipeline to which to add this stage.
         stage_name (str): Name of the stage.
 
     Returns:

--- a/edxpipelines/pipelines/manual_verification.py
+++ b/edxpipelines/pipelines/manual_verification.py
@@ -9,6 +9,7 @@ sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))
 
 import edxpipelines.utils as utils
 import edxpipelines.constants as constants
+import edxpipelines.patterns.stages as stages
 
 
 @click.command()
@@ -88,17 +89,7 @@ def install_pipeline(save_config_locally, dry_run, variable_files, cmd_line_vars
     #
     # Once the second phase is approved, the workflow will continue and pipelines downstream will continue to execute
     # with the same pinned materials from the upstream pipeline.
-    initial_verfication_stage = pipeline.ensure_stage(constants.INITIAL_VERIFICATION_STAGE_NAME)
-    initial_verfication_job = initial_verfication_stage.ensure_job(constants.INITIAL_VERIFICATION_JOB_NAME)
-    initial_verfication_job.add_task(
-        ExecTask(
-            [
-                '/bin/bash',
-                '-c',
-                'echo Initial Verification run number $GO_PIPELINE_COUNTER started by $GO_TRIGGER_USER'
-            ],
-        )
-    )
+    stages.generate_armed_stage(pipeline, constants.INITIAL_VERIFICATION_STAGE_NAME)
 
     manual_verification_stage = pipeline.ensure_stage(constants.MANUAL_VERIFICATION_STAGE_NAME)
     manual_verification_stage.set_has_manual_approval()

--- a/edxpipelines/pipelines/rollback_asgs.py
+++ b/edxpipelines/pipelines/rollback_asgs.py
@@ -91,8 +91,11 @@ def install_pipeline(save_config_locally, dry_run, variable_files, cmd_line_vars
         artifact_config['artifact_name']
     )
 
+    # Create the armed stage as this pipeline needs to auto-execute
+    stages.generate_armed_stage(pipeline, constants.ARMED_JOB_NAME)
+
     # Create a single stage in the pipeline which will rollback to the previous ASGs/AMI.
-    stages.generate_rollback_asg_stage(
+    rollback_stage = stages.generate_rollback_asg_stage(
         pipeline,
         config['asgard_api_endpoints'],
         config['asgard_token'],
@@ -102,6 +105,8 @@ def install_pipeline(save_config_locally, dry_run, variable_files, cmd_line_vars
         constants.HIPCHAT_ROOM,
         deploy_file_location,
     )
+    # Since we only want this stage to rollback via manual approval, ensure that it is set on this stage.
+    rollback_stage.set_has_manual_approval()
 
     gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
 


### PR DESCRIPTION
@edx/pipeline-team @maxrothman PTAL.

This will ensure material SHAs are kept consistent when an ASG needs to be rolled back.