### PR TITLE
Build edxapp production AMIs earlier in pipeline.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -160,7 +160,7 @@ tools:
   - script: edxpipelines/pipelines/manual_verification.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp-manual-verification-early-ami-build.yml"
+      - "../gomatic-secure/gocd/vars/tools/environment-play/edxapp-manual-verification-latest.yml"
       - *prod-stage-edxapp
     enabled: True
 

--- a/config.yml
+++ b/config.yml
@@ -1,11 +1,38 @@
+anchors:
+  ## This section exists to provide anchors for the pipelines below.
+  ## Place config files used multiple times as additional anchors here to avoid duplication.
+  - &tools-admin "../gomatic-secure/gocd/vars/tools/admin.yml"
+
+  - &deployment-edx      "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+  - &deployment-edge     "../gomatic-secure/gocd/vars/tools/deployments/edge.yml"
+  - &deployment-mckinsey "../gomatic-secure/gocd/vars/tools/deployments/mckinsey.yml"
+
+  - &stage-edx     "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
+  - &prod-edx      "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edx.yml"
+  - &prod-edge     "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edge.yml"
+  - &prod-mckinsey "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-mckinsey.yml"
+  - &loadtest-edx  "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
+
+  - &play-edxapp      "../gomatic-secure/gocd/vars/tools/plays/edxapp.yml"
+  - &play-ecommerce   "../gomatic-secure/gocd/vars/tools/plays/ecommerce.yml"
+  - &play-ecomworker  "../gomatic-secure/gocd/vars/tools/plays/ecomworker.yml"
+  - &play-credentials "../gomatic-secure/gocd/vars/tools/plays/credentials.yml"
+  - &play-programs    "../gomatic-secure/gocd/vars/tools/plays/programs.yml"
+  - &play-discovery   "../gomatic-secure/gocd/vars/tools/plays/discovery.yml"
+
+  - &prod-stage-edxapp         "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp.yml"
+  - &prod-stage-edxapp-private "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp-private.yml"
+
+  - &prerelease_upstream "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-prerelease-upstream.yml"
+
 tools:
   ## Start of 'Janitors' pipeline group
 
   #ASG cleanup for edge
   - script: edxpipelines/pipelines/asg_cleanup.py
     input_files:
-      - &tools-admin "../gomatic-secure/gocd/vars/tools/admin.yml"
-      - &edge-deployment "../gomatic-secure/gocd/vars/tools/deployments/edge.yml"
+      - *tools-admin
+      - *deployment-edge
       - "../gomatic-secure/gocd/vars/tools/asg-cleanup-edge.yml"
     enabled: True
 
@@ -13,7 +40,7 @@ tools:
   - script: edxpipelines/pipelines/asg_cleanup.py
     input_files:
       - *tools-admin
-      - &edx-deployment "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *deployment-edx
       - "../gomatic-secure/gocd/vars/tools/asg-cleanup-edx.yml"
     enabled: True
 
@@ -21,7 +48,7 @@ tools:
   - script: edxpipelines/pipelines/asg_cleanup.py
     input_files:
       - *tools-admin
-      - &mckinsey-deployment "../gomatic-secure/gocd/vars/tools/deployments/mckinsey.yml"
+      - *deployment-mckinsey
       - "../gomatic-secure/gocd/vars/tools/asg-cleanup-mckinsey.yml"
     enabled: True
   # End of 'Janitors' pipeline group
@@ -36,21 +63,21 @@ tools:
   - script: edxpipelines/pipelines/deploy_ami.py
     input_files:
       - *tools-admin
-      - *edx-deployment
+      - *deployment-edx
       - "../gomatic-secure/gocd/vars/tools/deploy_edx_ami.yml"
     enabled: True
 
   - script: edxpipelines/pipelines/deploy_ami.py
     input_files:
       - *tools-admin
-      - *edge-deployment
+      - *deployment-edge
       - "../gomatic-secure/gocd/vars/tools/deploy_edge_ami.yml"
     enabled: True
 
   - script: edxpipelines/pipelines/deploy_ami.py
     input_files:
       - *tools-admin
-      - *mckinsey-deployment
+      - *deployment-mckinsey
       - "../gomatic-secure/gocd/vars/tools/deploy_mckinsey_ami.yml"
     enabled: True
 
@@ -69,30 +96,149 @@ tools:
     enabled: False
 
 
+  ## START OF EDXAPP WHICH BUILDS PROD/EDGE AMIS in PARALLEL WITH STAGE DEPLOYMENT
+  # Starts the build of prod AMIs earlier in pipeline.
+
+  # Pre-release pipeline which includes all materials.
+  - script: edxpipelines/pipelines/prerelease_materials.py
+    input_files:
+      - *tools-admin
+      - *stage-edx
+      - *prod-stage-edxapp
+      - "../gomatic-secure/gocd/vars/tools/edxapp-prerelease-materials.yml"
+    enabled: True
+
+  # Now the three pipelines which fan-out from pre-release:
+  # - Stage B/M/D
+  # - prod-edx Build
+  # - prod-edge Build
+
+  # Stage edxapp B/M/D
+  - script: edxpipelines/pipelines/cd_edxapp.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-latest.yml"
+      - *stage-edx
+      - *prod-stage-edxapp
+      - *play-edxapp
+      - *deployment-edx
+      - *prerelease_upstream
+    enabled: True
+
+  # Prod edx of edxapp - but only building!
+  - script: edxpipelines/pipelines/cd_edxapp.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-build.yml"
+      - *prod-edx
+      - *prod-stage-edxapp
+      - *play-edxapp
+      - *deployment-edx
+      - *prerelease_upstream
+    bmd_steps: "b"
+    enabled: True
+
+    # Prod EDGE of edxapp - but only building!
+  - script: edxpipelines/pipelines/cd_edxapp.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-build.yml"
+      - *prod-edge
+      - *prod-stage-edxapp
+      - *play-edxapp
+      - *deployment-edge
+      - *prerelease_upstream
+    bmd_steps: "b"
+    enabled: True
+
+  # The three pipelines above fan-in to the following single pipeline, which allows manual
+  # gating of when/if a release candidate is pushed to production.
+
+  # Manual verification pipeline
+  - script: edxpipelines/pipelines/manual_verification.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp-manual-verification-early-ami-build.yml"
+      - *prod-stage-edxapp
+    enabled: True
+
+  # When manually triggered in the pipeline above, the following two pipelines migrate/deploy
+  # to the production EDX and EDGE environments.
+
+  # Prod edx of edxapp - only migration and deployment.
+  - script: edxpipelines/pipelines/cd_edxapp.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-migrate-deploy.yml"
+      - *prod-edx
+      - *prod-stage-edxapp
+      - *play-edxapp
+      - *deployment-edx
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-gated-upstream.yml"
+    bmd_steps: "md"
+    enabled: True
+
+  # Prod EDGE of edxapp - only migration and deployment.
+  - script: edxpipelines/pipelines/cd_edxapp.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-migrate-deploy.yml"
+      - *prod-edge
+      - *prod-stage-edxapp
+      - *play-edxapp
+      - *deployment-edge
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-gated-upstream.yml"
+    bmd_steps: "md"
+    enabled: True
+
+  # Then rollback pipelines for both EDX and EDGE are created below.
+
+  # Rollback pipeline for prod edx
+  - script: edxpipelines/pipelines/rollback_asgs.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-rollback-asgs-latest.yml"
+      - *prod-stage-edxapp
+      - *deployment-edx
+    enabled: True
+
+  # Rollback pipeline for prod edge
+  - script: edxpipelines/pipelines/rollback_asgs.py
+    input_files:
+      - *tools-admin
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-rollback-asgs-latest.yml"
+      - *prod-stage-edxapp
+      - *deployment-edge
+    enabled: True
+
+  ## END OF EDXAPP WHICH BUILDS PROD/EDGE AMIS in PARALLEL WITH STAGE DEPLOYMENT
+
   ## Start Edxapp
   # loadtest of edxapp
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-edxapp.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
+      - *loadtest-edx
       - "../gomatic-secure/gocd/vars/tools/environment-play/loadtest-edxapp.yml"
-      - &play-edxapp "../gomatic-secure/gocd/vars/tools/plays/edxapp.yml"
-      - &deployment-edx "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *play-edxapp
+      - *deployment-edx
     enabled: True
 
   # Stage edxapp
+  # DEPRECATED
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - &prod-stage-edxapp "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp.yml"
+      - *stage-edx
+      - *prod-stage-edxapp
       - *play-edxapp
       - *deployment-edx
     enabled: True
 
   # Manual verification pipeline
+  # DEPRECATED
   - script: edxpipelines/pipelines/manual_verification.py
     input_files:
       - *tools-admin
@@ -101,17 +247,19 @@ tools:
     enabled: True
 
   # Prod edx of edxapp
+  # DEPRECATED
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edx.yml"
+      - *prod-edx
       - *prod-stage-edxapp
       - *play-edxapp
       - *deployment-edx
     enabled: True
 
   # Rollback pipeline for prod edx
+  # DEPRECATED
   - script: edxpipelines/pipelines/rollback_asgs.py
     input_files:
       - *tools-admin
@@ -121,17 +269,19 @@ tools:
     enabled: True
 
   # Prod EDGE of edxapp
+  # DEPRECATED
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edge.yml"
+      - *prod-edge
       - *prod-stage-edxapp
       - *play-edxapp
-      - &deployment-edge "../gomatic-secure/gocd/vars/tools/deployments/edge.yml"
+      - *deployment-edge
     enabled: True
 
   # Rollback pipeline for prod edge
+  # DEPRECATED
   - script: edxpipelines/pipelines/rollback_asgs.py
     input_files:
       - *tools-admin
@@ -145,10 +295,10 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-mckinsey-edxapp.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-mckinsey.yml"
+      - *prod-mckinsey
       - *prod-stage-edxapp
       - *play-edxapp
-      - &deployment-mckinsey "../gomatic-secure/gocd/vars/tools/deployments/mckinsey.yml"
+      - *deployment-mckinsey
     enabled: True
 
     ## End Edxapp
@@ -159,8 +309,8 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-edxapp-private.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - &prod-stage-edxapp-private "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp-private.yml"
+      - *loadtest-edx
+      - *prod-stage-edxapp-private
       - *play-edxapp
       - *deployment-edx
     enabled: True
@@ -170,7 +320,7 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-private.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
+      - *stage-edx
       - *prod-stage-edxapp-private
       - *play-edxapp
       - *deployment-edx
@@ -189,7 +339,7 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-private.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edx.yml"
+      - *prod-edx
       - *prod-stage-edxapp-private
       - *play-edxapp
       - *deployment-edx
@@ -209,7 +359,7 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-private.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-edge.yml"
+      - *prod-edge
       - *prod-stage-edxapp-private
       - *play-edxapp
       - *deployment-edge
@@ -229,7 +379,7 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-mckinsey-edxapp-private.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/prod-mckinsey.yml"
+      - *prod-mckinsey
       - *prod-stage-edxapp-private
       - *play-edxapp
       - *deployment-mckinsey
@@ -268,9 +418,9 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-insights.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
+      - *stage-edx
       - "../gomatic-secure/gocd/vars/tools/plays/insights.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *deployment-edx
     enabled: True
 
   # Stage Analytics API
@@ -278,9 +428,9 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-analyticsapi.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
+      - *stage-edx
       - "../gomatic-secure/gocd/vars/tools/plays/analyticsapi.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *deployment-edx
     enabled: True
 
   # E-Commerce Apps
@@ -289,18 +439,18 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-ecommerce.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/ecommerce.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *stage-edx
+      - *play-ecommerce
+      - *deployment-edx
     enabled: True
 
   - script: edxpipelines/pipelines/cd_ecommerce.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-ecommerce.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/ecommerce.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *loadtest-edx
+      - *play-ecommerce
+      - *deployment-edx
     enabled: True
 
   # Credentials Service
@@ -308,18 +458,18 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-credentials.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/credentials.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *stage-edx
+      - *play-credentials
+      - *deployment-edx
     enabled: True
 
   - script: edxpipelines/pipelines/cd_credentials.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-credentials.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/credentials.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *loadtest-edx
+      - *play-credentials
+      - *deployment-edx
     enabled: True
 
   # Programs Service
@@ -327,18 +477,18 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-programs.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/programs.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *stage-edx
+      - *play-programs
+      - *deployment-edx
     enabled: True
 
   - script: edxpipelines/pipelines/cd_programs.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-programs.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/programs.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *loadtest-edx
+      - *play-programs
+      - *deployment-edx
     enabled: True
 
   # Catalog/Discovery Service
@@ -346,18 +496,18 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-discovery.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/discovery.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *stage-edx
+      - *play-discovery
+      - *deployment-edx
     enabled: True
 
   - script: edxpipelines/pipelines/cd_discovery.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-discovery.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/discovery.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *loadtest-edx
+      - *play-discovery
+      - *deployment-edx
     enabled: True
 
   # E-Commerce Worker
@@ -365,24 +515,24 @@ tools:
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-ecomworker.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/ecomworker.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *stage-edx
+      - *play-ecomworker
+      - *deployment-edx
     enabled: True
 
   - script: edxpipelines/pipelines/cd_ecomworker.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/loadtest-edx-ecomworker.yml"
-      - "../gomatic-secure/gocd/vars/tools/environment-deployments/loadtest-edx.yml"
-      - "../gomatic-secure/gocd/vars/tools/plays/ecomworker.yml"
-      - "../gomatic-secure/gocd/vars/tools/deployments/edx.yml"
+      - *loadtest-edx
+      - *play-ecomworker
+      - *deployment-edx
     enabled: True
 
 sandbox:
   - script: edxpipelines/pipelines/deploy_marketing_site.py
     input_files:
-      - &sandbox-admin "../gomatic-secure/gocd/vars/sandbox/admin.yml"
+      - "../gomatic-secure/gocd/vars/sandbox/admin.yml"
       - "../gomatic-secure/gocd/vars/sandbox/deploy_drupal.yml"
     enabled: False
 

--- a/config.yml
+++ b/config.yml
@@ -23,7 +23,9 @@ anchors:
   - &prod-stage-edxapp         "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp.yml"
   - &prod-stage-edxapp-private "../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp-private.yml"
 
-  - &prerelease_upstream "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-prerelease-upstream.yml"
+  - &prerelease_upstream     "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-prerelease-upstream.yml"
+  - &prod-edx-edxapp-latest  "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-latest.yml"
+  - &prod-edge-edxapp-latest "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-latest.yml"
 
 tools:
   ## Start of 'Janitors' pipeline group
@@ -129,7 +131,7 @@ tools:
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-build.yml"
+      - *prod-edx-edxapp-latest
       - *prod-edx
       - *prod-stage-edxapp
       - *play-edxapp
@@ -142,7 +144,7 @@ tools:
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-build.yml"
+      - *prod-edge-edxapp-latest
       - *prod-edge
       - *prod-stage-edxapp
       - *play-edxapp
@@ -169,7 +171,7 @@ tools:
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edx-edxapp-migrate-deploy.yml"
+      - *prod-edx-edxapp-latest
       - *prod-edx
       - *prod-stage-edxapp
       - *play-edxapp
@@ -182,7 +184,7 @@ tools:
   - script: edxpipelines/pipelines/cd_edxapp.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-migrate-deploy.yml"
+      - *prod-edge-edxapp-latest
       - *prod-edge
       - *prod-stage-edxapp
       - *play-edxapp

--- a/deploy_pipelines.py
+++ b/deploy_pipelines.py
@@ -10,11 +10,15 @@ import yaml
 logging.basicConfig(stream=sys.stdout, level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
 
 
-def ensure_pipeline(script, input_files, dry_run=False):
+def ensure_pipeline(script, input_files, bmd_steps, dry_run=False):
     script_args = []
 
     if dry_run:
         script_args.append('--dry-run')
+
+    if bmd_steps:
+        script_args.append('--bmd-steps')
+        script_args.append(bmd_steps)
 
     for input_file in input_files:
         script_args.append('--variable_file')
@@ -91,10 +95,20 @@ def run_pipelines(environment, config_file, script, verbose, dry_run):
     failures = []
     for script in scripts:
         try:
-            ensure_pipeline(script['script'], script['input_files'], dry_run)
+            ensure_pipeline(
+                script['script'],
+                script['input_files'],
+                script.get('bmd_steps', None),
+                dry_run
+            )
             success.append(script['script'])
         except subprocess.CalledProcessError, e:
-            failures.append({'script': script['script'], 'input_files': script['input_files'], 'error': e.output.split("\n")})
+            failures.append({
+                'script': script['script'],
+                'input_files': script['input_files'],
+                'bmd_steps': script.get('bmd_steps', None),
+                'error': e.output.split("\n")
+            })
 
     if len(success) > 0:
         print_success_report(success)

--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -21,6 +21,8 @@ ROLLBACK_ASGS_STAGE_NAME = 'rollback_asgs'
 ROLLBACK_ASGS_JOB_NAME = 'rollback_asgs_job'
 ARMED_STAGE_NAME = 'armed_stage'
 ARMED_JOB_NAME = 'armed_job'
+PRERELEASE_MATERIALS_STAGE_NAME = 'prerelease_materials'
+PRERELEASE_MATERIALS_JOB_NAME = 'prerelease_materials_job'
 
 # Tubular configuration
 TUBULAR_SLEEP_WAIT_TIME = '20'

--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -41,8 +41,10 @@ EDX_THEME_DIR = 'edx_theme'
 APP_REPO_BRANCH = 'master'
 HIPCHAT_ROOM = 'release'
 MATERIAL_IGNORE_ALL_REGEX = ['**/*']
+BUILD_AMI_FILENAME = 'ami.yml'
 DEPLOY_AMI_OUT_FILENAME = 'ami_deploy_info.yml'
 ROLLBACK_AMI_OUT_FILENAME = 'rollback_info.yml'
+LAUNCH_INSTANCE_FILENAME = 'launch_info.yml'
 
 # AWS Defaults
 EC2_REGION = 'us-east-1'
@@ -76,3 +78,11 @@ STAGE_TAG_NAME = 'test_tag_name'
 PROD_TAG_NAME = 'prod_tag_name'
 STAGE_ENV = 'test'
 PROD_ENV = 'prod'
+
+# key is the steps of the desired pipeline (build/migrate/deploy)
+# value is the suffix used for the pipeline name
+VALID_PIPELINE_STEP_PERMUTATIONS = {
+    'bmd': 'B-M-D',
+    'md': 'M-D',
+    'b': 'B'
+}

--- a/edxpipelines/pipelines/cd_edxapp.py
+++ b/edxpipelines/pipelines/cd_edxapp.py
@@ -31,6 +31,13 @@ import edxpipelines.constants as constants
     is_flag=True
 )
 @click.option(
+    '--bmd-steps',
+    envvar='BMD_STEPS',
+    help='Specify which steps to perform of build, migrate, deploy by specifying some subset of the letters "bmd".',
+    required=False,
+    default='bmd'
+)
+@click.option(
     '--variable_file', 'variable_files',
     multiple=True,
     help='Path to yaml variable file with a dictionary of key/value pairs to be used as variables in the script.',
@@ -46,7 +53,7 @@ import edxpipelines.constants as constants
     nargs=2,
     default={}
 )
-def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_vars):
+def install_pipelines(save_config_locally, dry_run, bmd_steps, variable_files, cmd_line_vars):
     """
     Variables needed for this pipeline:
     - gocd_username
@@ -67,12 +74,36 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
     - configuration_secure_version
     - configuration_internal_version
     """
+    BMD_STAGES = {
+        'b': generate_build_stages,
+        'm': generate_migrate_stages,
+        'd': generate_deploy_stages
+    }
+
+    # Sort the BMD steps by the custom 'bmd' alphabet
+    bmd_steps = utils.sort_bmd(bmd_steps.lower())
+
+    # validate the caller has requested a valid pipeline configuration
+    utils.validate_pipeline_permutations(bmd_steps)
+
+    # Merge the configuration files/variables together
     config = utils.merge_files_and_dicts(variable_files, list(cmd_line_vars,))
 
+    # Create the pipeline
     gcc = GoCdConfigurator(HostRestClient(config['gocd_url'], config['gocd_username'], config['gocd_password'], ssl=True))
-    pipeline = gcc.ensure_pipeline_group(config['pipeline_group'])\
-                  .ensure_replacement_of_pipeline(config['pipeline_name'])
+    pipeline_group = config['pipeline_group']
 
+    # Some pipelines will need to know the name of the upstream pipeline that built the AMI.
+    # Determine the build pipeline name and add it to the config.
+    pipeline_name, pipeline_name_build = utils.determine_pipeline_names(config, bmd_steps)
+    if 'pipeline_name_build' in config:
+        raise Exception("The config 'pipeline_name_build' value exists but should only be programmatically generated!")
+    config['pipeline_name_build'] = pipeline_name_build
+
+    pipeline = gcc.ensure_pipeline_group(pipeline_group)\
+                  .ensure_replacement_of_pipeline(pipeline_name)
+
+    # Setup the materials
     # Example materials yaml
     # materials:
     #   - url: "https://github.com/edx/tubular"
@@ -82,8 +113,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
     #     destination_directory: "tubular"
     #     ignore_patterns:
     #     - '**/*'
-
-    for material in config['materials']:
+    for material in config.get('materials', []):
         pipeline.ensure_material(
             GitMaterial(
                 url=material['url'],
@@ -95,7 +125,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    # If no upstream pipelines exist, don't install them!
+    # Setup the upstream pipeline materials
     for material in config.get('upstream_pipelines', []):
         pipeline.ensure_material(
             PipelineMaterial(
@@ -105,9 +135,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    #
-    # Create the AMI-building stage.
-    #
+    # We always need to launch the AMI, independent deploys are done with a different pipeline
     launch_stage = stages.generate_launch_instance(
         pipeline,
         config['aws_access_key_id'],
@@ -119,6 +147,17 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         manual_approval=not config.get('auto_run', False)
     )
 
+    # Generate all the requested stages
+    for phase in bmd_steps:
+        BMD_STAGES[phase](pipeline, config)
+
+    # Add the cleanup stage
+    generate_cleanup_stages(pipeline, config)
+
+    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
+
+
+def generate_build_stages(pipeline, config):
     stages.generate_run_play(
         pipeline,
         'playbooks/edx-east/edxapp.yml',
@@ -163,6 +202,10 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         edxapp_theme_version='$GO_REVISION_EDX_MICROSITE',
     )
 
+    return pipeline
+
+
+def generate_migrate_stages(pipeline, config):
     #
     # Create the DB migration running stage.
     #
@@ -182,7 +225,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         pipeline.name,
         constants.LAUNCH_INSTANCE_STAGE_NAME,
         constants.LAUNCH_INSTANCE_JOB_NAME,
-        'launch_info.yml'
+        constants.LAUNCH_INSTANCE_FILENAME
     )
     for sub_app in config['edxapp_subapps']:
         stages.generate_run_migrations(
@@ -197,14 +240,18 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             sub_application_name=sub_app
         )
 
+    return pipeline
+
+
+def generate_deploy_stages(pipeline, config):
     #
     # Create the stage to deploy the AMI.
     #
     ami_file_location = utils.ArtifactLocation(
-        pipeline.name,
+        config['pipeline_name_build'],
         constants.BUILD_AMI_STAGE_NAME,
         constants.BUILD_AMI_JOB_NAME,
-        'ami.yml'
+        constants.BUILD_AMI_FILENAME
     )
     stages.generate_deploy_ami(
         pipeline,
@@ -215,15 +262,18 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         ami_file_location,
         manual_approval=not config.get('auto_deploy_ami', False)
     )
+    return pipeline
 
+
+def generate_cleanup_stages(pipeline, config):
     #
     # Create the stage to terminate the EC2 instance used to both build the AMI and run DB migrations.
     #
     instance_info_location = utils.ArtifactLocation(
-        pipeline.name,
+        config['pipeline_name_build'],
         constants.LAUNCH_INSTANCE_STAGE_NAME,
         constants.LAUNCH_INSTANCE_JOB_NAME,
-        'launch_info.yml'
+        constants.LAUNCH_INSTANCE_FILENAME
     )
     stages.generate_terminate_instance(
         pipeline,
@@ -233,8 +283,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         hipchat_auth_token=config['hipchat_token'],
         runif='any'
     )
-
-    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
+    return pipeline
 
 
 if __name__ == "__main__":

--- a/edxpipelines/pipelines/prerelease_materials.py
+++ b/edxpipelines/pipelines/prerelease_materials.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+import sys
+from os import path
+import click
+from gomatic import *
+
+# Used to import edxpipelines files - since the module is not installed.
+sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+
+import edxpipelines.utils as utils
+import edxpipelines.patterns.stages as stages
+import edxpipelines.patterns.pipelines as pipelines
+import edxpipelines.constants as constants
+
+
+@click.command()
+@click.option(
+    '--save-config', 'save_config_locally',
+    envvar='SAVE_CONFIG',
+    help='Save the pipeline configuration xml locally.',
+    required=False,
+    default=False,
+    is_flag=True
+)
+@click.option(
+    '--dry-run',
+    envvar='DRY_RUN',
+    help='Perform a dry run of the pipeline installation, and save the pre/post xml configurations locally.',
+    required=False,
+    default=False,
+    is_flag=True
+)
+@click.option(
+    '--variable_file', 'variable_files',
+    multiple=True,
+    help='Path to yaml variable file with a dictionary of key/value pairs to be used as variables in the script.',
+    required=False,
+    default=[]
+)
+@click.option(
+    '-e', '--variable', 'cmd_line_vars',
+    multiple=True,
+    help='Key/value used as a replacement variable in this script, as in KEY=VALUE.',
+    required=False,
+    type=(str, str),
+    nargs=2,
+    default={}
+)
+def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_vars):
+    """
+    Variables needed for this pipeline:
+    - gocd_username
+    - gocd_password
+    - gocd_url
+    - configuration_secure_repo
+    - hipchat_token
+    - github_private_key
+    - aws_access_key_id
+    - aws_secret_access_key
+    - ec2_vpc_subnet_id
+    - ec2_security_group_id
+    - ec2_instance_profile_name
+    - base_ami_id
+
+    Optional variables:
+    - configuration_secure_version
+    """
+    config = utils.merge_files_and_dicts(variable_files, list(cmd_line_vars,))
+
+    gcc = GoCdConfigurator(HostRestClient(config['gocd_url'], config['gocd_username'], config['gocd_password'], ssl=True))
+    pipeline = gcc.ensure_pipeline_group(config['pipeline_group'])\
+                  .ensure_replacement_of_pipeline(config['pipeline_name'])
+
+    # Example materials yaml
+    # materials:
+    #   - url: "https://github.com/edx/tubular"
+    #     branch: "master"
+    #     material_name: "tubular"
+    #     polling: "True"
+    #     destination_directory: "tubular"
+    #     ignore_patterns:
+    #     - '**/*'
+
+    for material in config['materials']:
+        pipeline.ensure_material(
+            GitMaterial(
+                url=material['url'],
+                branch=material['branch'],
+                material_name=material['material_name'],
+                polling=material['polling'],
+                destination_directory=material['destination_directory'],
+                ignore_patterns=material['ignore_patterns']
+            )
+        )
+
+    # If no upstream pipelines exist, don't install them!
+    for material in config.get('upstream_pipelines', []):
+        pipeline.ensure_material(
+            PipelineMaterial(
+                pipeline_name=material['pipeline_name'],
+                stage_name=material['stage_name'],
+                material_name=material['material_name']
+            )
+        )
+
+    prerelease_materials_stage = pipeline.ensure_stage(constants.PRERELEASE_MATERIALS_STAGE_NAME)
+    prerelease_materials_stage.set_has_manual_approval()
+    prerelease_materials_job = prerelease_materials_stage.ensure_job(constants.PRERELEASE_MATERIALS_JOB_NAME)
+    prerelease_materials_job.add_task(
+        ExecTask(
+            [
+                '/bin/bash',
+                '-c',
+                'echo Initial prerelease stage - run number $GO_PIPELINE_COUNTER completed by $GO_TRIGGER_USER'
+            ],
+        )
+    )
+
+    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
+
+
+if __name__ == "__main__":
+    install_pipelines()

--- a/edxpipelines/pipelines/prerelease_materials.py
+++ b/edxpipelines/pipelines/prerelease_materials.py
@@ -103,18 +103,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    prerelease_materials_stage = pipeline.ensure_stage(constants.PRERELEASE_MATERIALS_STAGE_NAME)
-    prerelease_materials_stage.set_has_manual_approval()
-    prerelease_materials_job = prerelease_materials_stage.ensure_job(constants.PRERELEASE_MATERIALS_JOB_NAME)
-    prerelease_materials_job.add_task(
-        ExecTask(
-            [
-                '/bin/bash',
-                '-c',
-                'echo Initial prerelease stage - run number $GO_PIPELINE_COUNTER completed by $GO_TRIGGER_USER'
-            ],
-        )
-    )
+    stages.generate_armed_stage(pipeline, constants.PRERELEASE_MATERIALS_STAGE_NAME)
 
     gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
 

--- a/edxpipelines/tests/test_utils.py
+++ b/edxpipelines/tests/test_utils.py
@@ -3,6 +3,7 @@ import unittest
 
 from ddt import ddt, data, unpack
 import edxpipelines.utils as util
+import edxpipelines.constants as constants
 
 
 @ddt
@@ -106,3 +107,67 @@ class TestDictMerge(unittest.TestCase):
         merged = util.merge_files_and_dicts(file_paths, list(dicts))
         print merged
         self.assertEqual(merged, expected)
+
+
+@ddt
+class TestPipelineHelpers(unittest.TestCase):
+    @data(
+        ('bmd', 'bmd'),
+        ('bdm', 'bmd'),
+        ('mbd', 'bmd'),
+        ('mdb', 'bmd'),
+        ('dmb', 'bmd'),
+        ('dbm', 'bmd'),
+        ('md', 'md'),
+        ('dm', 'md'),
+        ('b', 'b'),
+    )
+    @unpack
+    def test_sort_bmd(self, permutation, expected):
+        self.assertEqual(util.sort_bmd(permutation), expected)
+
+    @data(
+        'bmdc',
+        'abcdefg',
+        '12356'
+    )
+    def test_sort_failure(self, permutation):
+        """
+        Sort should fail if we pass in letters that are not part of the bmd alphabet
+        """
+        self.assertRaises(Exception, util.sort_bmd, permutation)
+
+    @data(
+        'b',
+        'bmd',
+        'md'
+    )
+    def test_validate_pipeline_permutations(self, permutation):
+        self.assertTrue(util.validate_pipeline_permutations(permutation))
+
+    @data(
+        'abc',
+        'dmb',
+        'dm',
+        'bmmd',
+        'bbmdd'
+
+    )
+    def test_invalid_pipeline_permutations(self, permutation):
+        self.assertRaises(Exception, util.validate_pipeline_permutations, permutation)
+
+    @data(
+        ({'pipeline_name': 'blah'}, 'bmd', ('blah_B-M-D', 'blah_B-M-D')),
+        ({'pipeline_name': 'blah'}, 'md', ('blah_M-D', 'blah_B')),
+        ({'pipeline_name': 'blah'}, 'b', ('blah_B', 'blah_B')),
+    )
+    @unpack
+    def test_determine_pipeline_names(self, config, bmd_steps, expected_tuple):
+        self.assertEqual(util.determine_pipeline_names(config, bmd_steps), expected_tuple)
+
+    @data(
+        ({'pipeline_name': 'blah'}, 'dmb'),
+    )
+    @unpack
+    def test_invalid_input_determine_pipeline_names(self, config, bmd_steps):
+        self.assertRaises(KeyError, util.determine_pipeline_names, config, bmd_steps)

--- a/edxpipelines/utils.py
+++ b/edxpipelines/utils.py
@@ -1,5 +1,6 @@
 import yaml
 from collections import namedtuple
+from constants import VALID_PIPELINE_STEP_PERMUTATIONS
 from copy import copy
 
 
@@ -111,3 +112,60 @@ def merge_files_and_dicts(file_paths, dicts):
 
     [file_variables.append(d) for d in dict_vars]
     return dict_merge(*file_variables)
+
+
+def sort_bmd(bmd_steps):
+    """
+
+    Args:
+        bmd_steps (str): The string of letters to be sorted
+
+    Returns:
+        str: a sorted string according the the custom alphabet
+
+    Raises:
+        Exception: if any character is not part of the custom alphabet
+
+    """
+    alphabet = 'bmd'
+    try:
+        return ''.join(sorted(bmd_steps, key=lambda pipeline_stage: alphabet.index(pipeline_stage)))
+    except ValueError:
+        raise Exception(
+            'only valid stages are b, m, d and must be one of {}'.format(VALID_PIPELINE_STEP_PERMUTATIONS.keys())
+        )
+
+
+def validate_pipeline_permutations(bmd_steps):
+    """
+    Validates the bmd_steps matches one of the keys in constants.VALID_PIPELINE_STEP_PERMUTATIONS
+
+    Args:
+        bmd_steps (str): a valid bmd combination
+
+    Returns:
+        True if the permutation is valid
+
+    Raises:
+        Exception: if the bmd_steps is not a valid permutation
+
+    """
+    if bmd_steps in VALID_PIPELINE_STEP_PERMUTATIONS:
+        return True
+    else:
+        raise Exception('Only supports total Build/Migrate/Deploy, Build-only, and Migrate/Deploy-only pipelines.')
+
+
+def determine_pipeline_names(config, bmd_steps):
+    """
+    Depending on whether the BMD steps of the pipeline, read/return the correct pipeline_name config vars.
+    """
+    def _generate_pipeline_name(config, bmd_steps):
+        return '{pipeline_name}_{suffix}'\
+            .format(pipeline_name=config['pipeline_name'], suffix=VALID_PIPELINE_STEP_PERMUTATIONS[bmd_steps])
+
+    pipeline_name = _generate_pipeline_name(config, bmd_steps)
+    pipeline_name_build = _generate_pipeline_name(config, 'b')
+    if bmd_steps == 'bmd':
+        pipeline_name_build = pipeline_name
+    return pipeline_name, pipeline_name_build


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1789

Companion PR:
https://github.com/edx-ops/gomatic-secure/pull/70

Makes changes needed to create the pipeline system which builds production AMIs for edx/edge while the stage B/M/D process is occurring, speeding up eventual production deployments.

The existing edxapp pipeline system for deployments is preserved, as it's a critical piece of infrastructure. After the new pipeline system is used and verified, the old edxapp pipeline system can be removed.

I modified the cd_edxapp.py script to be able to make build-only, M/D-only, or B/M/D pipelines, instead of breaking that up into three different scripts.

An approximation of what this pipeline system looks like can be seen on the tools GoCD instance in the `jeskew_test` pipeline group.

@edx/pipeline-team Please review.