### PR TITLE
Bring back old version of cd_edxapp.py for non-converted pipelines.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -116,7 +116,7 @@ tools:
   # - prod-edge Build
 
   # Stage edxapp B/M/D
-  - script: edxpipelines/pipelines/cd_edxapp.py
+  - script: edxpipelines/pipelines/cd_edxapp_latest.py
     input_files:
       - *tools-admin
       - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-latest.yml"
@@ -128,7 +128,7 @@ tools:
     enabled: True
 
   # Prod edx of edxapp - but only building!
-  - script: edxpipelines/pipelines/cd_edxapp.py
+  - script: edxpipelines/pipelines/cd_edxapp_latest.py
     input_files:
       - *tools-admin
       - *prod-edx-edxapp-latest
@@ -141,7 +141,7 @@ tools:
     enabled: True
 
     # Prod EDGE of edxapp - but only building!
-  - script: edxpipelines/pipelines/cd_edxapp.py
+  - script: edxpipelines/pipelines/cd_edxapp_latest.py
     input_files:
       - *tools-admin
       - *prod-edge-edxapp-latest
@@ -168,7 +168,7 @@ tools:
   # to the production EDX and EDGE environments.
 
   # Prod edx of edxapp - only migration and deployment.
-  - script: edxpipelines/pipelines/cd_edxapp.py
+  - script: edxpipelines/pipelines/cd_edxapp_latest.py
     input_files:
       - *tools-admin
       - *prod-edx-edxapp-latest
@@ -181,7 +181,7 @@ tools:
     enabled: True
 
   # Prod EDGE of edxapp - only migration and deployment.
-  - script: edxpipelines/pipelines/cd_edxapp.py
+  - script: edxpipelines/pipelines/cd_edxapp_latest.py
     input_files:
       - *tools-admin
       - *prod-edge-edxapp-latest

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -31,6 +31,13 @@ import edxpipelines.constants as constants
     is_flag=True
 )
 @click.option(
+    '--bmd-steps',
+    envvar='BMD_STEPS',
+    help='Specify which steps to perform of build, migrate, deploy by specifying some subset of the letters "bmd".',
+    required=False,
+    default='bmd'
+)
+@click.option(
     '--variable_file', 'variable_files',
     multiple=True,
     help='Path to yaml variable file with a dictionary of key/value pairs to be used as variables in the script.',
@@ -46,7 +53,7 @@ import edxpipelines.constants as constants
     nargs=2,
     default={}
 )
-def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_vars):
+def install_pipelines(save_config_locally, dry_run, bmd_steps, variable_files, cmd_line_vars):
     """
     Variables needed for this pipeline:
     - gocd_username
@@ -67,12 +74,36 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
     - configuration_secure_version
     - configuration_internal_version
     """
+    BMD_STAGES = {
+        'b': generate_build_stages,
+        'm': generate_migrate_stages,
+        'd': generate_deploy_stages
+    }
+
+    # Sort the BMD steps by the custom 'bmd' alphabet
+    bmd_steps = utils.sort_bmd(bmd_steps.lower())
+
+    # validate the caller has requested a valid pipeline configuration
+    utils.validate_pipeline_permutations(bmd_steps)
+
+    # Merge the configuration files/variables together
     config = utils.merge_files_and_dicts(variable_files, list(cmd_line_vars,))
 
+    # Create the pipeline
     gcc = GoCdConfigurator(HostRestClient(config['gocd_url'], config['gocd_username'], config['gocd_password'], ssl=True))
-    pipeline = gcc.ensure_pipeline_group(config['pipeline_group'])\
-                  .ensure_replacement_of_pipeline(config['pipeline_name'])
+    pipeline_group = config['pipeline_group']
 
+    # Some pipelines will need to know the name of the upstream pipeline that built the AMI.
+    # Determine the build pipeline name and add it to the config.
+    pipeline_name, pipeline_name_build = utils.determine_pipeline_names(config, bmd_steps)
+    if 'pipeline_name_build' in config:
+        raise Exception("The config 'pipeline_name_build' value exists but should only be programmatically generated!")
+    config['pipeline_name_build'] = pipeline_name_build
+
+    pipeline = gcc.ensure_pipeline_group(pipeline_group)\
+                  .ensure_replacement_of_pipeline(pipeline_name)
+
+    # Setup the materials
     # Example materials yaml
     # materials:
     #   - url: "https://github.com/edx/tubular"
@@ -82,8 +113,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
     #     destination_directory: "tubular"
     #     ignore_patterns:
     #     - '**/*'
-
-    for material in config['materials']:
+    for material in config.get('materials', []):
         pipeline.ensure_material(
             GitMaterial(
                 url=material['url'],
@@ -95,7 +125,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    # If no upstream pipelines exist, don't install them!
+    # Setup the upstream pipeline materials
     for material in config.get('upstream_pipelines', []):
         pipeline.ensure_material(
             PipelineMaterial(
@@ -105,9 +135,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    #
-    # Create the AMI-building stage.
-    #
+    # We always need to launch the AMI, independent deploys are done with a different pipeline
     launch_stage = stages.generate_launch_instance(
         pipeline,
         config['aws_access_key_id'],
@@ -119,6 +147,17 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         manual_approval=not config.get('auto_run', False)
     )
 
+    # Generate all the requested stages
+    for phase in bmd_steps:
+        BMD_STAGES[phase](pipeline, config)
+
+    # Add the cleanup stage
+    generate_cleanup_stages(pipeline, config)
+
+    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
+
+
+def generate_build_stages(pipeline, config):
     stages.generate_run_play(
         pipeline,
         'playbooks/edx-east/edxapp.yml',
@@ -163,6 +202,10 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         edxapp_theme_version='$GO_REVISION_EDX_MICROSITE',
     )
 
+    return pipeline
+
+
+def generate_migrate_stages(pipeline, config):
     #
     # Create the DB migration running stage.
     #
@@ -182,7 +225,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         pipeline.name,
         constants.LAUNCH_INSTANCE_STAGE_NAME,
         constants.LAUNCH_INSTANCE_JOB_NAME,
-        'launch_info.yml'
+        constants.LAUNCH_INSTANCE_FILENAME
     )
     for sub_app in config['edxapp_subapps']:
         stages.generate_run_migrations(
@@ -197,14 +240,18 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             sub_application_name=sub_app
         )
 
+    return pipeline
+
+
+def generate_deploy_stages(pipeline, config):
     #
     # Create the stage to deploy the AMI.
     #
     ami_file_location = utils.ArtifactLocation(
-        pipeline.name,
+        config['pipeline_name_build'],
         constants.BUILD_AMI_STAGE_NAME,
         constants.BUILD_AMI_JOB_NAME,
-        'ami.yml'
+        constants.BUILD_AMI_FILENAME
     )
     stages.generate_deploy_ami(
         pipeline,
@@ -215,15 +262,18 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         ami_file_location,
         manual_approval=not config.get('auto_deploy_ami', False)
     )
+    return pipeline
 
+
+def generate_cleanup_stages(pipeline, config):
     #
     # Create the stage to terminate the EC2 instance used to both build the AMI and run DB migrations.
     #
     instance_info_location = utils.ArtifactLocation(
-        pipeline.name,
+        config['pipeline_name_build'],
         constants.LAUNCH_INSTANCE_STAGE_NAME,
         constants.LAUNCH_INSTANCE_JOB_NAME,
-        'launch_info.yml'
+        constants.LAUNCH_INSTANCE_FILENAME
     )
     stages.generate_terminate_instance(
         pipeline,
@@ -233,8 +283,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
         hipchat_auth_token=config['hipchat_token'],
         runif='any'
     )
-
-    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
+    return pipeline
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-on for work on this ticket:
https://openedx.atlassian.net/browse/TE-1789

This change fixes the creation of duplicate pipelines for the ones currently in use. After the other pipelines are converted to the new edxapp pattern, we'll retire the old version of cd_edxapp.py.

@edx/pipeline-team Please review.