### PR TITLE
correct input variables for edxapp-edge-private-rollbackup pipeline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -306,7 +306,7 @@ tools:
   - script: edxpipelines/pipelines/rollback_asgs.py
     input_files:
       - *tools-admin
-      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-rollback-asgs.yml"
+      - "../gomatic-secure/gocd/vars/tools/environment-deployment-play/prod-edge-edxapp-private-rollback-asgs.yml"
       - *prod-stage-edxapp-private
       - *deployment-edge
     enabled: True


### PR DESCRIPTION
@feanil @doctoryes This will fix the pipeline automation failure.

We were passing an incorrect variable file to the prod-edge-edxapp-private rollback pipeline.