### PR TITLE
Add check for key continuous_delivery and do not put in ignore patterns for a material

### DIFF
--- a/edxpipelines/pipelines/prerelease_materials.py
+++ b/edxpipelines/pipelines/prerelease_materials.py
@@ -89,7 +89,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
                 material_name=material['material_name'],
                 polling=material['polling'],
                 destination_directory=material['destination_directory'],
-                ignore_patterns=material['ignore_patterns']
+                ignore_patterns=[] if material.get('continuous_delivery') else material['ignore_patterns']
             )
         )
 


### PR DESCRIPTION
@edx/pipeline-team PTAL, this is part 1/2 for continuous delivery of edxapp to stage.

cc: @cpennington 

part 2/2: https://github.com/edx-ops/gomatic-secure/pull/83