### PR TITLE
Add base AMI selection phase in prerelease pipeline.

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -23,6 +23,8 @@ ARMED_STAGE_NAME = 'armed_stage'
 ARMED_JOB_NAME = 'armed_job'
 PRERELEASE_MATERIALS_STAGE_NAME = 'prerelease_materials'
 PRERELEASE_MATERIALS_JOB_NAME = 'prerelease_materials_job'
+BASE_AMI_SELECTION_STAGE_NAME = 'select_base_ami'
+BASE_AMI_SELECTION_JOB_NAME = 'select_base_ami_job'
 
 # Tubular configuration
 TUBULAR_SLEEP_WAIT_TIME = '20'
@@ -45,6 +47,7 @@ BUILD_AMI_FILENAME = 'ami.yml'
 DEPLOY_AMI_OUT_FILENAME = 'ami_deploy_info.yml'
 ROLLBACK_AMI_OUT_FILENAME = 'rollback_info.yml'
 LAUNCH_INSTANCE_FILENAME = 'launch_info.yml'
+BASE_AMI_OVERRIDE_FILENAME = 'ami_override.yml'
 
 # AWS Defaults
 EC2_REGION = 'us-east-1'

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -146,6 +146,15 @@ def install_pipelines(save_config_locally, dry_run, bmd_steps, variable_files, c
             constants.BUILD_AMI_JOB_NAME,
             FetchArtifactFile(constants.BUILD_AMI_FILENAME)
         )
+    elif config['upstream_ami_selection']:
+        # If an upstream artifact is specified, use it.
+        ami_config = config['upstream_ami_selection']
+        ami_artifact = utils.ArtifactLocation(
+            ami_config['pipeline_name'],
+            ami_config['pipeline_stage'],
+            ami_config['pipeline_stage_job'],
+            FetchArtifactFile(ami_config['artifact_file'])
+        )
 
     launch_stage = stages.generate_launch_instance(
         pipeline,

--- a/edxpipelines/pipelines/prerelease_materials.py
+++ b/edxpipelines/pipelines/prerelease_materials.py
@@ -103,7 +103,18 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
-    stages.generate_armed_stage(pipeline, constants.PRERELEASE_MATERIALS_STAGE_NAME)
+    base_ami_id = ''
+    if 'base_ami_id' in config:
+        base_ami_id = config['base_ami_id']
+    stages.generate_base_ami_selection(
+        pipeline,
+        config['aws_access_key_id'],
+        config['aws_secret_access_key'],
+        config['play_name'],
+        config['edx_deployment'],
+        config['edx_environment'],
+        base_ami_id
+    )
 
     gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1814

The base AMI ID to use in building new AMIs will now be determined in the prerelease stage. The logic used to determine the base AMI ID will now be the same as the logic used in Alton. Uses the code introduced in this PR:
https://github.com/edx/tubular/pull/81

The new way that base AMI selection will work:
- If you simply run the prerelease pipeline via the "Play" button, the base AMI will be determined via looking at the active EDP cluster and choosing the same AMI that is active there.
- If you'd like to use an AMI of your own choosing, click the "Play Plus" button, set `BASE_AMI_ID_OVERRIDE` to "yes", and set `BASE_AMI_ID` to the AMI ID you'd like to use.
- If you'd like to fall-back to use the AMI ID specified in the config file, click the "Play Plus" button, set `BASE_AMI_ID_OVERRIDE` to "yes", and leave `BASE_AMI_ID` blank.
  - NOTE: The base_ami_id configuration values are now deprecated and will soon be removed - so this 3rd method will not be around much longer.

To see an example 2-pipeline system of how this will work, view these pipelines:
https://gocd.tools.edx.org/go/admin/pipelines/jeskew_prerelease_edxapp_materials_latest/general
https://gocd.tools.edx.org/go/admin/pipelines/jeskew_STAGE_edxapp_B-M-D/general

@edx/pipeline-team Please review.
@edx/devops FYI
