### PR TITLE
Add base AMI selection phase in prerelease pipeline (round 2)

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -23,6 +23,8 @@ ARMED_STAGE_NAME = 'armed_stage'
 ARMED_JOB_NAME = 'armed_job'
 PRERELEASE_MATERIALS_STAGE_NAME = 'prerelease_materials'
 PRERELEASE_MATERIALS_JOB_NAME = 'prerelease_materials_job'
+BASE_AMI_SELECTION_STAGE_NAME = 'select_base_ami'
+BASE_AMI_SELECTION_JOB_NAME = 'select_base_ami_job'
 
 # Tubular configuration
 TUBULAR_SLEEP_WAIT_TIME = '20'
@@ -45,6 +47,7 @@ BUILD_AMI_FILENAME = 'ami.yml'
 DEPLOY_AMI_OUT_FILENAME = 'ami_deploy_info.yml'
 ROLLBACK_AMI_OUT_FILENAME = 'rollback_info.yml'
 LAUNCH_INSTANCE_FILENAME = 'launch_info.yml'
+BASE_AMI_OVERRIDE_FILENAME = 'ami_override.yml'
 
 # AWS Defaults
 EC2_REGION = 'us-east-1'

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -50,6 +50,93 @@ def generate_asg_cleanup(pipeline,
     return stage
 
 
+def generate_base_ami_selection(pipeline,
+                                aws_access_key_id,
+                                aws_secret_access_key,
+                                play,
+                                deployment,
+                                edx_environment,
+                                base_ami_id,
+                                base_ami_id_override='no',
+                                manual_approval=False
+                                ):
+    """
+    Pattern to find a base AMI for a particular EDP. Generates 1 artifact:
+        ami_override.yml    - YAML file that contains information about which base AMI to use in building AMI
+
+    Args:
+        pipeline (gomatic.Pipeline):
+        aws_access_key_id (str): AWS key ID for auth
+        aws_secret_access_key (str): AWS secret key for auth
+        play (str): Pipeline's play.
+        deployment (str): Pipeline's deployment.
+        edx_environment (str): Pipeline's environment.
+        base_ami_id (str): the ami-id used to launch the instance
+        base_ami_id_override (str): "yes" to use the base_ami_id provided,
+                                    any other value to extract the base AMI ID from the provided EDP instead
+        manual_approval (bool): Should this stage require manual approval?
+
+    Returns:
+        gomatic.Stage
+    """
+    pipeline.ensure_encrypted_environment_variables(
+        {
+            'AWS_ACCESS_KEY_ID': aws_access_key_id,
+            'AWS_SECRET_ACCESS_KEY': aws_secret_access_key
+        }
+    )
+
+    pipeline.ensure_environment_variables(
+        {
+            'PLAY': play,
+            'DEPLOYMENT': deployment,
+            'EDX_ENVIRONMENT': edx_environment,
+            'BASE_AMI_ID': base_ami_id,
+            'BASE_AMI_ID_OVERRIDE': base_ami_id_override,
+        }
+    )
+
+    stage = pipeline.ensure_stage(constants.BASE_AMI_SELECTION_STAGE_NAME)
+
+    if manual_approval:
+        stage.set_has_manual_approval()
+
+    # Install the requirements.
+    job = stage.ensure_job(constants.BASE_AMI_SELECTION_JOB_NAME)
+    tasks.generate_requirements_install(job, 'tubular')
+
+    # Generate an base-AMI-ID-overriding artifact.
+    base_ami_override_artifact = '{artifact_path}/{file_name}'.format(
+        artifact_path=constants.ARTIFACT_PATH,
+        file_name=constants.BASE_AMI_OVERRIDE_FILENAME
+    )
+    job.ensure_artifacts(set([BuildArtifact(base_ami_override_artifact)]))
+    job.add_task(
+        ExecTask(
+            [
+                '/bin/bash',
+                '-c',
+                'mkdir -p {artifact_path};'
+                'if [ $BASE_AMI_ID_OVERRIDE != \'yes\' ];'
+                '  then echo "Finding base AMI ID from active ELB/ASG in EDP.";'
+                '  /usr/bin/python {ami_script} --environment $EDX_ENVIRONMENT --deployment $DEPLOYMENT --play $PLAY --out_file {override_artifact};'
+                'elif [ $BASE_AMI_ID != \'\' ];'
+                '  then echo "Using specified base AMI ID of \'$BASE_AMI_ID\'";'
+                '  echo "base_ami_id: $BASE_AMI_ID" > {override_artifact};'
+                'else echo "Using environment base AMI ID";'
+                '  echo "{empty_dict}" > {override_artifact}; fi;'.format(
+                    artifact_path='../' + constants.ARTIFACT_PATH,
+                    ami_script='scripts/retrieve_base_ami.py',
+                    empty_dict='{}',
+                    override_artifact='../' + base_ami_override_artifact
+                )
+            ],
+            working_dir="tubular",
+            runif="passed"
+        )
+    )
+
+
 def generate_launch_instance(pipeline,
                              aws_access_key_id,
                              aws_secret_access_key,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -146,6 +146,15 @@ def install_pipelines(save_config_locally, dry_run, bmd_steps, variable_files, c
             constants.BUILD_AMI_JOB_NAME,
             FetchArtifactFile(constants.BUILD_AMI_FILENAME)
         )
+    elif 'upstream_ami_selection' in config:
+        # If an upstream artifact is specified, use it.
+        ami_config = config['upstream_ami_selection']
+        ami_artifact = utils.ArtifactLocation(
+            ami_config['pipeline_name'],
+            ami_config['pipeline_stage'],
+            ami_config['pipeline_stage_job'],
+            FetchArtifactFile(ami_config['artifact_file'])
+        )
 
     launch_stage = stages.generate_launch_instance(
         pipeline,

--- a/edxpipelines/pipelines/prerelease_materials.py
+++ b/edxpipelines/pipelines/prerelease_materials.py
@@ -103,7 +103,22 @@ def install_pipelines(save_config_locally, dry_run, variable_files, cmd_line_var
             )
         )
 
+    # This stage only logs material information - but needed to be left in temporarily
+    # as it used to be a stage that was an upstream material for three other pipelines.
     stages.generate_armed_stage(pipeline, constants.PRERELEASE_MATERIALS_STAGE_NAME)
+
+    base_ami_id = ''
+    if 'base_ami_id' in config:
+        base_ami_id = config['base_ami_id']
+    stages.generate_base_ami_selection(
+        pipeline,
+        config['aws_access_key_id'],
+        config['aws_secret_access_key'],
+        config['play_name'],
+        config['edx_deployment'],
+        config['edx_environment'],
+        base_ami_id
+    )
 
     gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
 


### PR DESCRIPTION
The changes in this PR have been merged and reverted before, due to an error in running the Gomatic. The error was caused by removing a stage that was an upstream dependency of three different pipelines. Here's the history:

The original PR (with details of how the feature works):
https://github.com/edx/edx-gomatic/pull/101

Fixes to the original PR - uncaught due to not attempting a test with `--dry-run` specified:
https://github.com/edx/edx-gomatic/pull/103

The code in this form still had a Gomatic error, which was:
```
Scripts failed:
INFO:root:script: {'bmd_steps': None,
 'error': ['Traceback (most recent call last):',
           '  File "edxpipelines/pipelines/prerelease_materials.py", line 123, in <module>',
           '    install_pipelines()',
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/click/core.py", line 716, in __call__',
           '    return self.main(*args, **kwargs)',
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/click/core.py", line 696, in main',
           '    rv = self.invoke(ctx)',
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/click/core.py", line 889, in invoke',
           '    return ctx.invoke(self.callback, **ctx.params)',
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/click/core.py", line 534, in invoke',
           '    return callback(*args, **kwargs)',
           '  File "edxpipelines/pipelines/prerelease_materials.py", line 119, in install_pipelines',
           '    gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)',
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/gomatic/go_cd_configurator.py", line 203, in save_updated_config',
           "    self.__host_rest_client.post('/go/admin/restful/configuration/file/POST/xml', data)",
           '  File "/Users/jeskew/Envs/edx-gomatic/lib/python2.7/site-packages/gomatic/go_cd_configurator.py", line 235, in post',
           '    raise RuntimeError("Could not post config to Go server (%s) [status code=%s]:\\n%s" % (url, result.status_code, message))',
           'RuntimeError: Could not post config to Go server (https://gocd.tools.edx.org/go/admin/restful/configuration/file/POST/xml) [status code=409]:',
           "Stage with name 'prerelease_materials' does not exist on pipeline 'prerelease_edxapp_materials_latest'",
           ''],
 'input_files': ['../gomatic-secure/gocd/vars/tools/admin.yml',
                 '../gomatic-secure/gocd/vars/tools/plays/edxapp.yml',
                 '../gomatic-secure/gocd/vars/tools/deployments/edx.yml',
                 '../gomatic-secure/gocd/vars/tools/environment-deployments/stage-edx.yml',
                 '../gomatic-secure/gocd/vars/tools/environment-play/prod-stage-edxapp.yml',
                 '../gomatic-secure/gocd/vars/tools/edxapp-prerelease-materials.yml'],
 'script': 'edxpipelines/pipelines/prerelease_materials.py'}
```

So - a revert PR was made:
https://github.com/edx/edx-gomatic/pull/104

But the revert PR was hand-crafted hurriedly - and had a mistake which continued to cause the Gomatic error. The mistake was corrected in this PR:
https://github.com/edx/edx-gomatic/pull/105

Now - this PR incorporates all the code above into a change that should successfully enable the base AMI selection feature.

*“Those who cannot remember the past are condemned to repeat it.”* - George Santayana

@edx/pipeline-team Please review.