### PR TITLE
Add upstream_ami_selection section to prod edx/edge files as well.

### DIFF
--- a/edxpipelines/pipelines/config/prod-edge-edxapp-latest.yml
+++ b/edxpipelines/pipelines/config/prod-edge-edxapp-latest.yml
@@ -2,3 +2,8 @@ pipeline_group: "edxapp_prod_deploys"
 pipeline_name: "PROD_edge_edxapp"
 auto_run: "True"
 auto_deploy_ami: "True"
+upstream_ami_selection:
+  pipeline_name: "prerelease_edxapp_materials_latest"
+  pipeline_stage: "select_base_ami"
+  pipeline_stage_job: "select_base_ami_job"
+  artifact_file: "ami_override.yml"

--- a/edxpipelines/pipelines/config/prod-edx-edxapp-latest.yml
+++ b/edxpipelines/pipelines/config/prod-edx-edxapp-latest.yml
@@ -2,3 +2,8 @@ pipeline_group: "edxapp_prod_deploys"
 pipeline_name: "PROD_edx_edxapp"
 auto_run: "True"
 auto_deploy_ami: "True"
+upstream_ami_selection:
+  pipeline_name: "prerelease_edxapp_materials_latest"
+  pipeline_stage: "select_base_ami"
+  pipeline_stage_job: "select_base_ami_job"
+  artifact_file: "ami_override.yml"


### PR DESCRIPTION
The `PROD_{edx|edge}_edxapp_B` were *not* using the base AMI found by the base AMI selection code in the upstream prerelease pipeline - they were instead using the hard-coded base AMI IDs in the config files. After this change, those pipelines will use the same base AMI that's used in the `STAGE_edxapp_B-M-D` pipeline. This is a bug fix for the original base AMI selection changes.

@edx/pipeline-team @cpennington Please review.