### PR TITLE
Revert "Add upstream_ami_selection section to prod edx/edge files as well."

### DIFF
--- a/edxpipelines/pipelines/config/prod-edge-edxapp-latest.yml
+++ b/edxpipelines/pipelines/config/prod-edge-edxapp-latest.yml
@@ -2,8 +2,3 @@ pipeline_group: "edxapp_prod_deploys"
 pipeline_name: "PROD_edge_edxapp"
 auto_run: "True"
 auto_deploy_ami: "True"
-upstream_ami_selection:
-  pipeline_name: "prerelease_edxapp_materials_latest"
-  pipeline_stage: "select_base_ami"
-  pipeline_stage_job: "select_base_ami_job"
-  artifact_file: "ami_override.yml"

--- a/edxpipelines/pipelines/config/prod-edx-edxapp-latest.yml
+++ b/edxpipelines/pipelines/config/prod-edx-edxapp-latest.yml
@@ -2,8 +2,3 @@ pipeline_group: "edxapp_prod_deploys"
 pipeline_name: "PROD_edx_edxapp"
 auto_run: "True"
 auto_deploy_ami: "True"
-upstream_ami_selection:
-  pipeline_name: "prerelease_edxapp_materials_latest"
-  pipeline_stage: "select_base_ami"
-  pipeline_stage_job: "select_base_ami_job"
-  artifact_file: "ami_override.yml"


### PR DESCRIPTION
Reverts edx/edx-gomatic#114

The base AMI selection code needs to grab the AMI IDs for each EDP separately instead of using a common AMI_ID. Until the code is changed to do so, reverting this change.

@edx/pipeline-team @cpennington Please review.