### PR TITLE
Add branch merging and tagging into edxapp pipeline.

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -10,8 +10,8 @@ TERMINATE_INSTANCE_STAGE_NAME = 'cleanup_ami_Instance'
 TERMINATE_INSTANCE_JOB_NAME = 'cleanup_ami_instance_job'
 LAUNCH_INSTANCE_STAGE_NAME = 'launch_instance'
 LAUNCH_INSTANCE_JOB_NAME = 'launch_instance_job'
-RUN_PLAY_STAGE_NAME = "run_play"
-RUN_PLAY_JOB_NAME = "run_play_job"
+RUN_PLAY_STAGE_NAME = 'run_play'
+RUN_PLAY_JOB_NAME = 'run_play_job'
 APPLY_MIGRATIONS_STAGE = 'apply_migrations'
 APPLY_MIGRATIONS_JOB = 'apply_migrations_job'
 INITIAL_VERIFICATION_STAGE_NAME = 'initial_verification'
@@ -37,7 +37,16 @@ MESSAGE_PR_PROD_NAME = 'message_pr_on_prod'
 MESSAGE_PR_PROD_JOB_NAME = 'message_pr_on_prod_JOB'
 MESSAGE_PR_ROLLBACK_NAME = 'message_pr_rollback'
 MESSAGE_PR_ROLLBACK_JOB_NAME = 'message_pr_rollback_JOB'
+GIT_MERGE_RC_BRANCH_STAGE_NAME = 'merge_rc_branch'
+GIT_MERGE_RC_BRANCH_JOB_NAME = 'merge_rc_branch_job'
+GIT_TAG_SHA_JOB_NAME = 'tag_deployed_commit_job'
+CREATE_MASTER_MERGE_PR_STAGE_NAME = 'create_master_merge_pr'
+CREATE_MASTER_MERGE_PR_JOB_NAME = 'create_master_merge_pr_job'
+CHECK_PR_TESTS_AND_MERGE_STAGE_NAME = 'check_pr_tests_and_merge'
+CHECK_PR_TESTS_AND_MERGE_JOB_NAME = 'check_pr_tests_and_merge_job'
 
+# Pipeline names
+BRANCH_CLEANUP_PIPELINE_NAME = 'edxapp_branch_cleanup'
 
 # Tubular configuration
 TUBULAR_SLEEP_WAIT_TIME = '20'
@@ -62,6 +71,8 @@ ROLLBACK_AMI_OUT_FILENAME = 'rollback_info.yml'
 LAUNCH_INSTANCE_FILENAME = 'launch_info.yml'
 BASE_AMI_OVERRIDE_FILENAME = 'ami_override.yml'
 CREATE_BRANCH_FILENAME = 'branch.yml'
+MERGE_BRANCH_FILENAME = 'merge_branch_sha.yml'
+CREATE_BRANCH_PR_FILENAME = 'create_branch_pr.yml'
 
 # AWS Defaults
 EC2_REGION = 'us-east-1'

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -315,6 +315,23 @@ def install_pipelines(save_config_locally, dry_run, variable_files,
         cmd_line_vars
     )
 
+    merge_back = edxapp.merge_back_branches(
+        edxapp_deploy_group,
+        constants.BRANCH_CLEANUP_PIPELINE_NAME,
+        variable_files,
+        cmd_line_vars
+    )
+
+    # Specify the upstream deploy pipeline materials for this branch-merging pipeline.
+    for deploy_pipeline in (prod_edx_md, prod_edge_md):
+        merge_back.ensure_material(
+            PipelineMaterial(
+                pipeline_name=deploy_pipeline.name,
+                stage_name=constants.DEPLOY_AMI_STAGE_NAME,
+                material_name='deploy_pipeline_{}'.format(deploy_pipeline.name),
+            )
+        )
+
     gcc.save_updated_config(save_config_locally=save_config_locally, dry_run=dry_run)
 
 if __name__ == "__main__":

--- a/edxpipelines/pipelines/config/edxapp.yml
+++ b/edxpipelines/pipelines/config/edxapp.yml
@@ -4,3 +4,10 @@ edxapp_subapps:
   - lms
 play_name: "edxapp"
 db_migration_user: "www-data"
+
+github_org: edx
+github_repo: edx-platform
+rc_branch: release-candidate
+release_branch: release
+release_to_master_branch: release-mergeback-to-master
+master_branch: master

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,5 +3,6 @@ nose==1.3.7
 moto==0.4.21
 mock==2.0.0
 pep8==1.7.0
+tox==2.5.0
 
 -r ../requirements.txt


### PR DESCRIPTION
Part of: https://openedx.atlassian.net/browse/TE-1739

Blocked until merging of this PR:
https://github.com/edx/tubular/pull/99

Adds a separate pipeline to the edxapp pipeline system whose upstream dependencies are the prod deployment pipelines. The pipeline has three stages which perform the following functions:
* fast-forward merge the release-candidate branch into the release branch
* create a branch off release and create PR to merge the new branch to master
* poll PR tests until they pass/fail and, upon success, merge the PR

@edx/pipeline-team @cpennington Please review.