### PR TITLE
Send deploy artifact to tag creation script for deploy time.

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -474,7 +474,7 @@ def rollback_asgs(edxapp_deploy_group, pipeline_name, build_pipeline, deploy_pip
     return pipeline
 
 
-def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_pipeline_name, variable_files, cmd_line_vars):
+def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_artifact, variable_files, cmd_line_vars):
     """
     Arguments:
         edxapp_deploy_group (gomatic.PipelineGroup): The group in which to create this pipeline
@@ -506,7 +506,7 @@ def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_pipeline_name
     stages.generate_merge_branch_and_tag(
         pipeline,
         constants.GIT_MERGE_RC_BRANCH_STAGE_NAME,
-        deploy_pipeline_name,
+        deploy_artifact,
         org=config['github_org'],
         repo=config['github_repo'],
         target_branch=config['release_branch'],

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -474,11 +474,12 @@ def rollback_asgs(edxapp_deploy_group, pipeline_name, build_pipeline, deploy_pip
     return pipeline
 
 
-def merge_back_branches(edxapp_deploy_group, pipeline_name, variable_files, cmd_line_vars):
+def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_pipeline_name, variable_files, cmd_line_vars):
     """
     Arguments:
         edxapp_deploy_group (gomatic.PipelineGroup): The group in which to create this pipeline
         pipeline_name (str): The name of this pipeline
+        deploy_pipeline_name (str): The name of the deploy pipeline from which to fetch an artifact.
 
     Configuration Required:
         github_org
@@ -505,6 +506,7 @@ def merge_back_branches(edxapp_deploy_group, pipeline_name, variable_files, cmd_
     stages.generate_merge_branch_and_tag(
         pipeline,
         constants.GIT_MERGE_RC_BRANCH_STAGE_NAME,
+        deploy_pipeline_name,
         org=config['github_org'],
         repo=config['github_repo'],
         target_branch=config['release_branch'],

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -1222,6 +1222,7 @@ def generate_message_prs(pipeline,
 
 def generate_merge_branch_and_tag(pipeline,
                                   stage_name,
+                                  deploy_pipeline_name,
                                   org,
                                   repo,
                                   target_branch,
@@ -1237,6 +1238,7 @@ def generate_merge_branch_and_tag(pipeline,
     Args:
         pipeline (gomatic.Pipeline): Pipeline to which this stage will be attached
         stage_name (str): Name of the stage
+        deploy_pipeline_name (str): Name of deploy pipeline from which to fetch artifact
         org (str): Name of the github organization that holds the repository (e.g. edx)
         repo (str): Name of repository (e.g edx-platform)
         target_branch (str): Name of the branch into which to merge the source branch
@@ -1271,11 +1273,24 @@ def generate_merge_branch_and_tag(pipeline,
     # Generate a job/task which tags the head commit of the source branch.
     # Instruct the task to auto-generate tag name/message by not sending them in.
     tag_job = git_stage.ensure_job(constants.GIT_TAG_SHA_JOB_NAME)
+
+    # Fetch the AMI-deployment artifact to extract deployment time.
+    tag_job.add_task(
+        FetchArtifactTask(
+            pipeline=deploy_pipeline_name,
+            stage=constants.DEPLOY_AMI_STAGE_NAME,
+            job=constants.DEPLOY_AMI_JOB_NAME,
+            src=FetchArtifactFile(constants.DEPLOY_AMI_OUT_FILENAME),
+            dest=constants.ARTIFACT_PATH
+        )
+    )
+
     tasks.generate_tag_commit(
         tag_job,
         org,
         repo,
-        commit_sha=head_sha
+        commit_sha=head_sha,
+        deploy_artifact=constants.DEPLOY_AMI_OUT_FILENAME
     )
 
 

--- a/edxpipelines/patterns/tasks.py
+++ b/edxpipelines/patterns/tasks.py
@@ -1012,6 +1012,7 @@ def generate_tag_commit(job,
                         input_file=None,
                         commit_sha=None,
                         branch_name=None,
+                        deploy_artifact=None,
                         tag_name=None,
                         tag_message=None,
                         runif='passed'):
@@ -1059,6 +1060,11 @@ def generate_tag_commit(job,
         cmd_args.extend(('--tag_name', tag_name))
     if tag_message:
         cmd_args.extend(('--tag_message', tag_message))
+    if deploy_artifact:
+        cmd_args.append('--deploy_artifact ../{artifact_path}/{deploy_artifact}'.format(
+            artifact_path=constants.ARTIFACT_PATH,
+            deploy_artifact=deploy_artifact
+        ))
 
     return job.add_task(
         ExecTask(

--- a/edxpipelines/patterns/tasks.py
+++ b/edxpipelines/patterns/tasks.py
@@ -1012,7 +1012,7 @@ def generate_tag_commit(job,
                         input_file=None,
                         commit_sha=None,
                         branch_name=None,
-                        deploy_artifact=None,
+                        deploy_artifact_filename=None,
                         tag_name=None,
                         tag_message=None,
                         runif='passed'):
@@ -1032,6 +1032,7 @@ def generate_tag_commit(job,
         input_file (str): Name of file containing commit SHA.
         commit_sha (str): Commit SHA to tag.
         branch_name (str): Branch name whose HEAD will be tagged.
+        deploy_artifact_filename (str): Filename of the deploy artifact.
         tag_name (str): Name to use for the commit tag.
         tag_message (str): Message to use for the commit tag.
         runif (str): one of ['passed', 'failed', 'any'] Default: passed
@@ -1060,10 +1061,10 @@ def generate_tag_commit(job,
         cmd_args.extend(('--tag_name', tag_name))
     if tag_message:
         cmd_args.extend(('--tag_message', tag_message))
-    if deploy_artifact:
-        cmd_args.append('--deploy_artifact ../{artifact_path}/{deploy_artifact}'.format(
+    if deploy_artifact_filename:
+        cmd_args.append('--deploy_artifact ../{artifact_path}/{deploy_artifact_filename}'.format(
             artifact_path=constants.ARTIFACT_PATH,
-            deploy_artifact=deploy_artifact
+            deploy_artifact_filename=deploy_artifact_filename
         ))
 
     return job.add_task(

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -318,6 +318,7 @@ def install_pipelines(save_config_locally, dry_run, variable_files,
     merge_back = edxapp.merge_back_branches(
         edxapp_deploy_group,
         constants.BRANCH_CLEANUP_PIPELINE_NAME,
+        prod_edx_md.name,
         variable_files,
         cmd_line_vars
     )

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -315,10 +315,17 @@ def install_pipelines(save_config_locally, dry_run, variable_files,
         cmd_line_vars
     )
 
+    deploy_artifact = utils.ArtifactLocation(
+        prod_edx_md.name,
+        constants.DEPLOY_AMI_STAGE_NAME,
+        constants.DEPLOY_AMI_JOB_NAME,
+        FetchArtifactFile(constants.DEPLOY_AMI_OUT_FILENAME)
+    )
+
     merge_back = edxapp.merge_back_branches(
         edxapp_deploy_group,
         constants.BRANCH_CLEANUP_PIPELINE_NAME,
-        prod_edx_md.name,
+        deploy_artifact,
         variable_files,
         cmd_line_vars
     )


### PR DESCRIPTION
Instead of using a different time for the tag upon each time the tagging stage is re-run, use the deploy artifact to use a consistent time.

Depends on: https://github.com/edx/tubular/pull/111

@edx/pipeline-team @cpennington Please review.