### PR TITLE
Remove extra space in PR polling call.

### DIFF
--- a/edxpipelines/patterns/tasks.py
+++ b/edxpipelines/patterns/tasks.py
@@ -1172,7 +1172,7 @@ def generate_poll_pr_tests(job,
             [
                 '/bin/bash',
                 '-c',
-                ' '.join(command),
+                command,
             ],
             working_dir='tubular',
             runif=runif


### PR DESCRIPTION
Space is the place. 
   - Sun Ra

@edx/pipeline-team @cpennington Please review.