### PR TITLE
Fetch the rollback migrations ami artifact from the ami build step

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -557,7 +557,7 @@ def rollback_database(build_pipeline, deploy_pipeline):
         pipeline.ensure_material(
             PipelineMaterial(
                 pipeline_name=build_pipeline.name,
-                stage_name=constants.BASE_AMI_SELECTION_STAGE_NAME,
+                stage_name=constants.BUILD_AMI_STAGE_NAME,
                 material_name='select_base_ami',
             )
         )

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -297,9 +297,9 @@ def install_pipelines(configurator, config, env_configs):
         pipeline_name="PROD_edx_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
             prod_edx_b.name,
-            constants.BASE_AMI_SELECTION_STAGE_NAME,
-            constants.BASE_AMI_SELECTION_JOB_NAME,
-            constants.BASE_AMI_OVERRIDE_FILENAME
+            constants.BUILD_AMI_STAGE_NAME,
+            constants.BUILD_AMI_JOB_NAME,
+            constants.BUILD_AMI_FILENAME
         ),
         auto_run=False,
         pre_launch_builders=[
@@ -316,9 +316,9 @@ def install_pipelines(configurator, config, env_configs):
         pipeline_name="PROD_edge_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
             prod_edge_b.name,
-            constants.BASE_AMI_SELECTION_STAGE_NAME,
-            constants.BASE_AMI_SELECTION_JOB_NAME,
-            constants.BASE_AMI_OVERRIDE_FILENAME
+            constants.BUILD_AMI_STAGE_NAME,
+            constants.BUILD_AMI_JOB_NAME,
+            constants.BUILD_AMI_FILENAME
         ),
         auto_run=False,
         pre_launch_builders=[


### PR DESCRIPTION
Have the migrations rollback pipeline use the AMI that was built during the build phase to rollback migrations.