### PR TITLE
Execute install tubular scripts, rather than calling them via python2

### DIFF
--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -49,8 +49,7 @@ def generate_asg_cleanup(pipeline,
     tasks.generate_package_install(job, 'tubular')
     job.add_task(ExecTask(
         [
-            '/usr/bin/python',
-            'scripts/cleanup-asgs.py'
+            'cleanup-asgs.py'
         ],
         working_dir="tubular"
     ))
@@ -388,8 +387,7 @@ def generate_deploy_ami(
     job.ensure_artifacts(set([BuildArtifact(artifact_path)]))
 
     deploy_command =\
-        '/usr/bin/python ' \
-        'scripts/asgard-deploy.py ' \
+        'asgard-deploy.py ' \
         '--out_file ../{} '.format(artifact_path)
 
     if upstream_ami_artifact:
@@ -446,8 +444,7 @@ def generate_edp_validation(pipeline,
     job.add_task(
         ExecTask(
             [
-                '/usr/bin/python',
-                'scripts/validate_edp.py'
+                'validate_edp.py'
             ],
             working_dir='tubular'
         )
@@ -457,8 +454,7 @@ def generate_edp_validation(pipeline,
             [
                 '/bin/bash',
                 '-c',
-                '/usr/bin/python '
-                'scripts/submit_hipchat_msg.py '
+                'submit_hipchat_msg.py '
                 '-m '
                 '"${AMI_ID} is not tagged for ${AMI_ENVIRONMENT}-${AMI_DEPLOYMENT}-${AMI_PLAY}. '
                 'Are you sure you\'re deploying the right AMI to the right app?" '
@@ -765,8 +761,7 @@ def generate_rollback_asg_stage(
 
     job.add_task(ExecTask(
         [
-            '/usr/bin/python',
-            'scripts/rollback_asg.py',
+            'rollback_asg.py',
             '--config_file', deploy_file_location.file_name,
             '--out_file', '../{}'.format(artifact_path),
         ],

--- a/edxpipelines/patterns/tasks.py
+++ b/edxpipelines/patterns/tasks.py
@@ -606,7 +606,7 @@ def _fetch_secure_repo(job, secure_dir, secure_repo_envvar, secure_version_envva
         """\
             touch github_key.pem &&
             chmod 600 github_key.pem &&
-            python tubular/scripts/format_rsa_key.py --key "$PRIVATE_GITHUB_KEY" --output-file github_key.pem &&
+            format_rsa_key.py --key "$PRIVATE_GITHUB_KEY" --output-file github_key.pem &&
             GIT_SSH_COMMAND='/usr/bin/ssh -o StrictHostKeyChecking=no -i github_key.pem'
             /usr/bin/git clone ${secure_repo_envvar} {secure_dir} &&
             cd {secure_dir} &&
@@ -1556,19 +1556,19 @@ def generate_base_ami_selection(
             mkdir -p {artifact_path};
             if [[ $BASE_AMI_ID_OVERRIDE != 'yes' ]];
                 then echo "Finding base AMI ID from active ELB/ASG in EDP.";
-                /usr/bin/python {ami_script}
+                {ami_script}
                     --environment $EDX_ENVIRONMENT
                     --deployment $DEPLOYMENT
                     --play $PLAY
                     --out_file {override_artifact};
             elif [[ -n $BASE_AMI_ID ]];
                 then echo "Using specified base AMI ID of '$BASE_AMI_ID'";
-                /usr/bin/python {ami_script} --override $BASE_AMI_ID --out_file {override_artifact};
+                {ami_script} --override $BASE_AMI_ID --out_file {override_artifact};
             else echo "Using environment base AMI ID";
                 echo "{empty_dict}" > {override_artifact}; fi;
         """,
         artifact_path='../' + constants.ARTIFACT_PATH,
-        ami_script='scripts/retrieve_base_ami.py',
+        ami_script='retrieve_base_ami.py',
         empty_dict='{}',
         override_artifact='../' + base_ami_override_artifact,
         working_dir="tubular",


### PR DESCRIPTION
Not merging this will cause code to break the next time we deploy the agents.