### PR TITLE
Create a new branch for each release candidate

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -51,7 +51,7 @@ def cut_branch(edxapp_group, config):
     return pipeline
 
 
-def prerelease_materials(edxapp_group):
+def prerelease_materials(edxapp_group, config):
     """
     Variables needed for this pipeline:
     - gocd_username
@@ -81,7 +81,16 @@ def prerelease_materials(edxapp_group):
 
     pipeline.ensure_material(TUBULAR())
 
-    stages.generate_armed_stage(pipeline, constants.ARM_PRERELEASE_STAGE)
+    stage = pipeline.ensure_stage(constants.PRERELEASE_MATERIALS_STAGE_NAME)
+    job = stage.ensure_job(constants.PRERELEASE_MATERIALS_JOB_NAME)
+
+    # This prevents the commit being released from being lost when the new
+    # release-candidate is cut. However, this will require a janitor job to
+    # deal with any releases that are never completed.
+    tasks.generate_create_branch(
+        pipeline, job, config['git_token'], 'edx', 'edx-platform',
+        target_branch="release-candidate/$GO_PIPELINE_COUNTER",
+        sha='$GO_REVISION_EDX_PLATFORM')
 
     return pipeline
 

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -1044,11 +1044,6 @@ def generate_create_branch(pipeline,
     Returns:
         gomatic.Stage
     """
-    pipeline.ensure_unencrypted_secure_environment_variables(
-        {
-            'GIT_TOKEN': token
-        }
-    )
     git_stage = pipeline.ensure_stage(stage_name)
     if manual_approval:
         git_stage.set_has_manual_approval()
@@ -1056,7 +1051,9 @@ def generate_create_branch(pipeline,
     tasks.generate_package_install(git_job, 'tubular')
     tasks.generate_target_directory(git_job)
     tasks.generate_create_branch(
+        pipeline,
         git_job,
+        token,
         org,
         repo,
         target_branch,
@@ -1269,11 +1266,6 @@ def generate_create_branch_and_pr(pipeline,
     Returns:
         gomatic.Stage
     """
-    pipeline.ensure_unencrypted_secure_environment_variables(
-        {
-            'GIT_TOKEN': token
-        }
-    )
     git_stage = pipeline.ensure_stage(stage_name)
     if manual_approval:
         git_stage.set_has_manual_approval()
@@ -1283,7 +1275,9 @@ def generate_create_branch_and_pr(pipeline,
 
     # Generate a task that creates a new branch off the HEAD of a source branch.
     tasks.generate_create_branch(
+        pipeline,
         git_job,
+        token,
         org,
         repo,
         target_branch=new_branch,

--- a/edxpipelines/patterns/tasks.py
+++ b/edxpipelines/patterns/tasks.py
@@ -1013,7 +1013,9 @@ def generate_create_release_candidate_branch_and_pr(job,  # pylint: disable=inva
     ))
 
 
-def generate_create_branch(job,
+def generate_create_branch(pipeline,
+                           job,
+                           token,
                            org,
                            repo,
                            target_branch,
@@ -1025,7 +1027,9 @@ def generate_create_branch(job,
         Assumes a secure environment variable named "GIT_TOKEN"
 
     Args:
+        pipeline (gomatic.Pipeline): The Pipeline to insert environment variables into.
         job (gomatic.Job): the Job to attach this stage to.
+        token (str): The github token to use with the API.
         org (str): Name of the github organization that holds the repository (e.g. edx)
         repo (str): Name of repository (e.g edx-platform)
         target_branch (str): Name of the branch to be created (will be the head of the PR)
@@ -1037,6 +1041,12 @@ def generate_create_branch(job,
         The newly created task (gomatic.gocd.tasks.ExecTask)
 
     """
+    pipeline.ensure_unencrypted_secure_environment_variables(
+        {
+            'GIT_TOKEN': token
+        }
+    )
+
     args = [
         '--org', org,
         '--repo', repo,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -73,6 +73,7 @@ def install_pipelines(configurator, config, env_configs):
     )
     prerelease_materials = edxapp.prerelease_materials(
         edxapp_group,
+        config
     )
 
     stage_b = edxapp.launch_and_terminate_subset_pipeline(
@@ -136,7 +137,7 @@ def install_pipelines(configurator, config, env_configs):
         pipeline.ensure_material(
             PipelineMaterial(
                 pipeline_name=prerelease_materials.name,
-                stage_name=constants.ARM_PRERELEASE_STAGE,
+                stage_name=constants.PRERELEASE_MATERIALS_STAGE_NAME,
                 material_name="prerelease",
             )
         )


### PR DESCRIPTION
This prevents the commit being released from being lost when the new
release-candidate is cut. However, this will require a janitor job to
deal with any releases that are never completed.