### PR TITLE
Pipelines to cleanup dangling EC2 instances

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,6 +51,27 @@ tools:
       - *deployment-mckinsey
       - "../gomatic-secure/gocd/vars/tools/asg-cleanup-mckinsey.yml"
     enabled: True
+
+  #Instance cleanup for edx
+  - script: edxpipelines/pipelines/instance_cleanup.py
+    variable_file:
+      - *tools-admin
+      - *deployment-edx
+    enabled: True
+
+  #Instance cleanup for edge
+  - script: edxpipelines/pipelines/instance_cleanup.py
+    variable_file:
+      - *tools-admin
+      - *deployment-edge
+    enabled: True
+
+  #Instance cleanup for McKinsey
+  - script: edxpipelines/pipelines/instance_cleanup.py
+    variable_file:
+      - *tools-admin
+      - *deployment-mckinsey
+    enabled: True
   # End of 'Janitors' pipeline group
 
   - script: edxpipelines/pipelines/build_edxapp_ami.py

--- a/config.yml
+++ b/config.yml
@@ -52,26 +52,16 @@ tools:
       - "../gomatic-secure/gocd/vars/tools/asg-cleanup-mckinsey.yml"
     enabled: True
 
-  #Instance cleanup for edx
+  #Instance cleanup for edx/edge/mckinsey
   - script: edxpipelines/pipelines/instance_cleanup.py
     variable_file:
       - *tools-admin
-      - *deployment-edx
+    env-variable-file:
+      - ['edx', *deployment-edx]
+      - ['edge', *deployment-edge]
+      - ['mckinsey', *deployment-mckinsey]
     enabled: True
 
-  #Instance cleanup for edge
-  - script: edxpipelines/pipelines/instance_cleanup.py
-    variable_file:
-      - *tools-admin
-      - *deployment-edge
-    enabled: True
-
-  #Instance cleanup for McKinsey
-  - script: edxpipelines/pipelines/instance_cleanup.py
-    variable_file:
-      - *tools-admin
-      - *deployment-mckinsey
-    enabled: True
   # End of 'Janitors' pipeline group
 
   - script: edxpipelines/pipelines/build_edxapp_ami.py

--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -55,6 +55,8 @@ CHECK_PR_TESTS_AND_MERGE_JOB_NAME = 'check_pr_tests_and_merge_job'
 BUILD_VALUE_STREAM_MAP_URL_STAGE_NAME = 'build_value_stream_map_url'
 BUILD_VALUE_STREAM_MAP_URL_JOB_NAME = 'build_value_stream_map_url_job'
 PUBLISH_WIKI_JOB_NAME = 'publish_wiki_job'
+INSTANCE_JANITOR_STAGE_NAME = 'janitor_instances'
+INSTANCE_JANITOR_JOB_NAME = 'janitor_instances_job'
 
 # Pipeline names
 BRANCH_CLEANUP_PIPELINE_NAME = 'edxapp_branch_cleanup'

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -454,6 +454,40 @@ def generate_ami_cleanup(job, hipchat_token, hipchat_room=constants.HIPCHAT_ROOM
     ))
 
 
+def generate_janitor_instance_cleanup(job,
+                                      name_match_pattern,
+                                      max_run_hours,
+                                      skip_if_tag,
+                                      ec2_region=constants.EC2_REGION,
+                                      runif='passed'):
+    """
+    Use in conjunction with patterns.generate_launch_instance this will cleanup the EC2 instances and associated actions
+
+    Args:
+        job (gomatic.job.Job): the gomatic job which to add the launch instance task
+        name_match_pattern (str): pattern to match the name of the instances that should be terminated
+        max_run_hours (int): number of hourse that should pass before terminating matching instances
+        skip_if_tag (str): if this tag exists on an instance, it will not be terminated
+        ec2_region (str): the EC2 region to connect
+        runif (str): one of ['passed', 'failed', 'any'] Default: passed
+
+    Returns:
+        The newly created task (gomatic.gocd.tasks.ExecTask)
+
+    """
+    return job.add_task(tubular_task(
+        script='cleanup_instances.py',
+        arguments=[
+            '--region {}'.format(ec2_region),
+            '--max_run_hours {}'.format(max_run_hours),
+            '--name_filter "{}"'.format(name_match_pattern),
+            '--skip_if_tag "{}"'.format(skip_if_tag)
+            ],
+        runif=runif
+        )
+    )
+
+
 def generate_run_migrations(
         job,
         application_user,

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -475,15 +475,16 @@ def generate_janitor_instance_cleanup(job,
         The newly created task (gomatic.gocd.tasks.ExecTask)
 
     """
-    return job.add_task(tubular_task(
-        script='cleanup_instances.py',
-        arguments=[
-            '--region {}'.format(ec2_region),
-            '--max_run_hours {}'.format(max_run_hours),
-            '--name_filter "{}"'.format(name_match_pattern),
-            '--skip_if_tag "{}"'.format(skip_if_tag)
+    return job.add_task(
+        tubular_task(
+            script='cleanup_instances.py',
+            arguments=[
+                '--region {}'.format(ec2_region),
+                '--max_run_hours {}'.format(max_run_hours),
+                '--name_filter "{}"'.format(name_match_pattern),
+                '--skip_if_tag "{}"'.format(skip_if_tag)
             ],
-        runif=runif
+            runif=runif
         )
     )
 

--- a/edxpipelines/pipelines/instance_cleanup.py
+++ b/edxpipelines/pipelines/instance_cleanup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""
+Script to install pipelines to clean up old ASGs.
+"""
+import sys
+from os import path
+
+# Used to import edxpipelines files - since the module is not installed.
+sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+
+# pylint: disable=wrong-import-position
+from edxpipelines import materials
+from edxpipelines.patterns import stages
+from edxpipelines.pipelines.script import pipeline_script
+
+
+def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+    """
+    Variables needed for this pipeline:
+    - aws_access_key_id
+    - aws_secret_access_key
+    - edx_deployment
+    """
+
+    pipeline = configurator.ensure_pipeline_group('Janitors')\
+                           .ensure_replacement_of_pipeline('Instance-Cleanup-{}'.format(config['edx_deployment']))\
+                           .set_timer('0 0,30 * * * ?')\
+                           .set_git_material(materials.TUBULAR())
+
+    stages.generate_cleanup_dangling_instances(
+        pipeline,
+        config['aws_access_key_id'],
+        config['aws_secret_access_key'],
+        name_match_pattern='gocd automation run*',
+        max_run_hours=24,
+        skip_if_tag='do_not_delete'
+    )
+
+if __name__ == "__main__":
+    pipeline_script(install_pipelines)

--- a/edxpipelines/pipelines/instance_cleanup.py
+++ b/edxpipelines/pipelines/instance_cleanup.py
@@ -21,20 +21,21 @@ def install_pipelines(configurator, config, env_configs):  # pylint: disable=unu
     - aws_secret_access_key
     - edx_deployment
     """
+    for _, env_config in env_configs.items():
+        pipeline_name = 'Instance-Cleanup-{}'.format(env_config['edx_deployment'])
+        pipeline = configurator.ensure_pipeline_group('Janitors')\
+                               .ensure_replacement_of_pipeline(pipeline_name)\
+                               .set_timer('0 0,30 * * * ?')\
+                               .set_git_material(materials.TUBULAR())
 
-    pipeline = configurator.ensure_pipeline_group('Janitors')\
-                           .ensure_replacement_of_pipeline('Instance-Cleanup-{}'.format(config['edx_deployment']))\
-                           .set_timer('0 0,30 * * * ?')\
-                           .set_git_material(materials.TUBULAR())
-
-    stages.generate_cleanup_dangling_instances(
-        pipeline,
-        config['aws_access_key_id'],
-        config['aws_secret_access_key'],
-        name_match_pattern='gocd automation run*',
-        max_run_hours=24,
-        skip_if_tag='do_not_delete'
-    )
+        stages.generate_cleanup_dangling_instances(
+            pipeline,
+            env_config['aws_access_key_id'],
+            env_config['aws_secret_access_key'],
+            name_match_pattern='gocd automation run*',
+            max_run_hours=24,
+            skip_if_tag='do_not_delete'
+        )
 
 if __name__ == "__main__":
-    pipeline_script(install_pipelines)
+    pipeline_script(install_pipelines, environments=('edx', 'edge', 'mckinsey'))


### PR DESCRIPTION
I put some of the config for variables we may want to tweak directly in the pipeline script code. Where do we want to store stuff like this?