### PR TITLE
Only trigger prerelease_edxapp_materials_latest on edx-platform-private changes

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -115,7 +115,7 @@ def prerelease_materials(edxapp_group, config):
     cut_rc.ensure_material(EDX_PLATFORM(material_name='edx-platform', ignore_patterns=[]))
 
     pipeline.ensure_material(TUBULAR())
-    pipeline.ensure_material(EDX_PLATFORM(ignore_patterns=[]))
+    pipeline.ensure_material(EDX_PLATFORM())
     pipeline.ensure_material(EDX_PLATFORM_PRIVATE(ignore_patterns=[]))
     pipeline.ensure_material(cut_rc_material)
 


### PR DESCRIPTION
This should prevent a race-condition where edx-platform-private hasn't been updated yet after edx-platform changes.