### PR TITLE
Only cut the new r-c if it's a fast-forward from the old r-c

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -48,7 +48,7 @@ def make_release_candidate(edxapp_group, config):
         'edx-platform',
         "origin/{}".format(edx_platform_master.branch),
         EDX_PLATFORM().branch,
-        fast_forward_only=False,
+        fast_forward_only=True,
         reference_repo='edx-platform',
     )
 


### PR DESCRIPTION
This PR makes the creation of the new release candidate fail if it's not a fast-forward merge up from the old release candidate to master. This will keep us from losing commits on the release candidate, while also making sure we're always cutting new release candidates from master.