### PR TITLE
Make prerelease-edxapp-materials-latest only trigger on the cut-priva…

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -110,7 +110,7 @@ def prerelease_materials(edxapp_group, config):
             EDX_MICROSITE, EDX_INTERNAL, EDGE_INTERNAL,
     ):
         cut_rc.ensure_material(material(ignore_patterns=[]))
-        pipeline.ensure_material(material(ignore_patterns=[]))
+        pipeline.ensure_material(material())
 
     cut_rc.ensure_material(TUBULAR())
     cut_rc.ensure_material(EDX_PLATFORM(material_name='edx-platform', ignore_patterns=[]))


### PR DESCRIPTION
…te-rc job and the edx-platform-private git material

This should make it so we have fewer places where this job triggers early where the edx-platform-private material hasn't been updated yet.