### PR TITLE
Add method to the GoCD url for release advancing.

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -83,7 +83,7 @@ def release_advancer(edxapp_group, config):
         constants.MANUAL_VERIFICATION_STAGE_NAME,
         config['gocd_username'],
         config['gocd_password'],
-        config['gocd_url'],
+        'https://{}'.format(config['gocd_url']),
         config['hipchat_token']
     )
 


### PR DESCRIPTION
Fixes this problem:
https://gocd.tools.edx.org/go/tab/build/detail/edxapp_release_advancer/3/advance_release/1/advance_release_job

The GoCD Python module we're using, yagocd, requires the method along with the FQDN.