### PR TITLE
Create the required artifact directory for release advancer.

### DIFF
--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -1430,6 +1430,9 @@ def generate_find_and_advance_release(
     job = stage.ensure_job(constants.RELEASE_ADVANCER_JOB_NAME)
     tasks.generate_package_install(job, 'tubular')
 
+    # Add task to generate the directory where the artifact file will be written.
+    tasks.generate_target_directory(job)
+
     pipeline.ensure_environment_variables(
         {
             'GOCD_USER': gocd_user,


### PR DESCRIPTION
Fixes this error:
https://gocd.tools.edx.org/go/tab/build/detail/edxapp_release_advancer/4/advance_release/1/advance_release_job

Should be the last one for this rascally pipeline! 🔨 
