### PR TITLE
Add a job for each dependent repo to check CI tests.

### DIFF
--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -58,6 +58,8 @@ INSTANCE_JANITOR_STAGE_NAME = 'janitor_instances'
 INSTANCE_JANITOR_JOB_NAME = 'janitor_instances_job'
 RELEASE_ADVANCER_STAGE_NAME = 'advance_release'
 RELEASE_ADVANCER_JOB_NAME = 'advance_release_job'
+CHECK_CI_STAGE_NAME = 'check_ci'
+CHECK_CI_JOB_NAME = 'check_ci_job'
 
 # Pipeline group names
 ORA2_PIPELINE_GROUP_NAME = 'ORA2'

--- a/edxpipelines/materials.py
+++ b/edxpipelines/materials.py
@@ -1,22 +1,66 @@
 """
 A set of standard overridable material definitions.
 """
+import re
 from functools import partial
+from six.moves import urllib
 
 from gomatic import GitMaterial
 
 
+class InvalidGitRepoURL(Exception):
+    """
+    Raised when repo URL can't be parsed.
+    """
+    pass
+
+
+class GomaticGitMaterial(GitMaterial):
+    """
+    Wrapper class around gomatic.gomatic.gocd.materials.GitMaterial in order to add helper methods.
+    """
+    def __init__(
+            self, url, branch=None, material_name=None, polling=True,
+            ignore_patterns=None, destination_directory=None
+    ):
+        # Parse out the org/repo from the material url.
+        clone_url = urllib.parse.urlparse(url).geturl()
+        match = re.match(r'.*[:/](?P<org>[^/]*)/(?P<repo>[^/.]*)', clone_url)
+        if not match:
+            raise InvalidGitRepoURL(url)
+        self.org = match.group('org')
+        self.repo = match.group('repo')
+        super(GomaticGitMaterial, self).__init__(
+            url, branch, material_name, polling, ignore_patterns, destination_directory
+        )
+
+    @property
+    def envvar_name(self):
+        """
+        Return the material revision's GoCD environment variable name.
+        """
+        suffix = self.material_name if self.material_name else self.destination_directory
+        return 'GO_REVISION_{suffix}'.format(suffix=suffix.replace('-', '_').upper())
+
+    @property
+    def envvar_bash(self):
+        """
+        Return the material revision's GoCD environment variable in de-referenced bash format.
+        """
+        return '${self.envvar_name}'.format(self=self)
+
+
 def deployment_secure(deployment, branch='master', polling=True, destination_directory=None, ignore_patterns=None):
     """
-    Initialize a GitMaterial representing a deployment's secure configuration repo.
+    Initialize a GomaticGitMaterial representing a deployment's secure configuration repo.
 
     Args:
         deployment (str): Deployment for which to create the material (e.g., 'edx', 'edge')
 
     Returns:
-        gomatic.gomatic.gocd.materials.GitMaterial
+        GomaticGitMaterial
     """
-    return GitMaterial(
+    return GomaticGitMaterial(
         url='git@github.com:edx-ops/{}-secure.git'.format(deployment),
         branch=branch,
         polling=polling,
@@ -27,15 +71,15 @@ def deployment_secure(deployment, branch='master', polling=True, destination_dir
 
 def deployment_internal(deployment, branch='master', polling=True, destination_directory=None, ignore_patterns=None):
     """
-    Initialize a GitMaterial representing a deployment's internal configuration repo.
+    Initialize a GomaticGitMaterial representing a deployment's internal configuration repo.
 
     Args:
         deployment (str): Deployment for which to create the material (e.g., 'edx', 'edge')
 
     Returns:
-        gomatic.gomatic.gocd.materials.GitMaterial
+        GomaticGitMaterial
     """
-    return GitMaterial(
+    return GomaticGitMaterial(
         url='git@github.com:edx/{}-internal.git'.format(deployment),
         branch=branch,
         polling=polling,
@@ -45,7 +89,7 @@ def deployment_internal(deployment, branch='master', polling=True, destination_d
 
 
 TUBULAR = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="https://github.com/edx/tubular",
     branch="master",
     polling=True,
@@ -54,7 +98,7 @@ TUBULAR = partial(
 )
 
 CONFIGURATION = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="https://github.com/edx/configuration",
     branch="master",
     polling=True,
@@ -63,7 +107,7 @@ CONFIGURATION = partial(
 )
 
 EDX_PLATFORM = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="https://github.com/edx/edx-platform",
     branch="release-candidate",
     polling=True,
@@ -76,7 +120,7 @@ EDX_SECURE = partial(deployment_secure, 'edx')
 EDGE_SECURE = partial(deployment_secure, 'edge')
 
 EDX_MICROSITE = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="git@github.com:edx/edx-microsite.git",
     branch="release",
     polling=True,
@@ -89,7 +133,7 @@ EDX_INTERNAL = partial(deployment_internal, 'edx')
 EDGE_INTERNAL = partial(deployment_internal, 'edge')
 
 EDX_MKTG = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="git@github.com:edx/edx-mktg.git",
     branch="master",
     polling=True,
@@ -98,7 +142,7 @@ EDX_MKTG = partial(
 )
 
 ECOM_SECURE = partial(
-    GitMaterial,
+    GomaticGitMaterial,
     url="git@github.com:edx-ops/ecom-secure",
     branch="master",
     polling=True,

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -162,7 +162,7 @@ def prerelease_materials(edxapp_group, config, stage_config, prod_edx_config, pr
     tasks.generate_create_branch(
         pipeline, job, config['git_token'], 'edx', 'edx-platform',
         target_branch="release-candidate-$GO_PIPELINE_COUNTER",
-        sha='$GO_REVISION_EDX_PLATFORM')
+        sha=EDX_PLATFORM().envvar_bash)
 
     # Move the AMI selection jobs here in a single stage.
     stage = pipeline.ensure_stage(constants.BASE_AMI_SELECTION_STAGE_NAME)
@@ -278,7 +278,7 @@ def generate_build_stages(app_repo, edp, theme_url, configuration_secure_repo,
             configuration_internal_dir='{}-internal'.format(edp.deployment),
             hipchat_token=config['hipchat_token'],
             hipchat_room='release',
-            configuration_version='$GO_REVISION_CONFIGURATION',
+            configuration_version=CONFIGURATION().envvar_bash,
             edxapp_theme_source_repo=theme_url,
             # Currently, edx-theme isn't exposed as a material. See https://openedx.atlassian.net/browse/TE-1874
             # edxapp_theme_version='$GO_REVISION_EDX_THEME',
@@ -300,17 +300,17 @@ def generate_build_stages(app_repo, edp, theme_url, configuration_secure_repo,
             pipeline,
             edp=edp,
             app_repo=app_repo,
-            app_version='$GO_REVISION_EDX_PLATFORM',
+            app_version=EDX_PLATFORM().envvar_bash,
             hipchat_token=config['hipchat_token'],
             hipchat_room='release pipeline',
             aws_access_key_id=config['aws_access_key_id'],
             aws_secret_access_key=config['aws_secret_access_key'],
             version_tags={
-                'edx_platform': (EDX_PLATFORM().url, '$GO_REVISION_EDX_PLATFORM'),
-                'configuration': (configuration_url, '$GO_REVISION_CONFIGURATION'),
+                'edx_platform': (EDX_PLATFORM().url, EDX_PLATFORM().envvar_bash),
+                'configuration': (configuration_url, CONFIGURATION().envvar_bash),
                 'configuration_secure': (configuration_secure_repo, configuration_secure_version),
                 'configuration_internal': (configuration_internal_repo, configuration_internal_version),
-                'edxapp_theme': (theme_url, '$GO_REVISION_EDX_MICROSITE'),
+                'edxapp_theme': (theme_url, EDX_MICROSITE().envvar_bash),
             }
         )
 
@@ -447,7 +447,7 @@ def generate_deploy_stages(
             'edx',
             'edx-platform',
             '$GITHUB_TOKEN',
-            '$GO_REVISION_EDX_PLATFORM',
+            EDX_PLATFORM().envvar_bash,
             constants.ReleaseStatus[config['edx_environment']],
             config['jira_user'],
             config['jira_password'],
@@ -514,16 +514,11 @@ def manual_verification(edxapp_deploy_group, config):
     # with the same pinned materials from the upstream pipeline.
     stages.generate_armed_stage(pipeline, constants.INITIAL_VERIFICATION_STAGE_NAME)
 
-    orgs_repos = []
-    # Add all repos for which to check CI tests in this list.
-    for material in [EDX_PLATFORM]:
-        # Parse out the org, repo from each material.
-        url_split = material().url.split(':')[-1].split('/')
-        orgs_repos.append((url_split[-2], url_split[-1].replace('.git', '')))
+    # Add all materials for which to check CI tests in this list.
     stages.generate_check_ci(
         pipeline,
         config['github_token'],
-        orgs_repos
+        [EDX_PLATFORM()]
     )
 
     manual_verification_stage = pipeline.ensure_stage(constants.MANUAL_VERIFICATION_STAGE_NAME)
@@ -673,7 +668,7 @@ def rollback_asgs(
         'edx',
         'edx-platform',
         '$GITHUB_TOKEN',
-        '$GO_REVISION_EDX_PLATFORM',
+        EDX_PLATFORM().envvar_bash,
         constants.ReleaseStatus.ROLLED_BACK,
         config['jira_user'],
         config['jira_password'],
@@ -815,7 +810,7 @@ def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_artifact, pre
         org='edx',
         repo='edx-platform',
         target_branch='release',
-        head_sha='$GO_REVISION_EDX_PLATFORM',
+        head_sha=EDX_PLATFORM().envvar_bash,
         fast_forward_only=True,
         reference_repo='edx-platform',
     )
@@ -825,7 +820,7 @@ def merge_back_branches(edxapp_deploy_group, pipeline_name, deploy_artifact, pre
         deploy_artifact=deploy_artifact,
         org='edx',
         repo='edx-platform',
-        head_sha='$GO_REVISION_EDX_PLATFORM',
+        head_sha=EDX_PLATFORM().envvar_bash,
     )
 
     jobs.generate_tag_commit(

--- a/edxpipelines/patterns/pipelines.py
+++ b/edxpipelines/patterns/pipelines.py
@@ -429,7 +429,7 @@ def generate_service_deployment_pipelines(
             env_config,
             version_tags={
                 edp.play: (app_material.url, app_version_var),
-                'configuration': (configuration_material.url, '$GO_REVISION_CONFIGURATION'),
+                'configuration': (configuration_material.url, configuration_material.envvar_bash),
                 'configuration_secure': (
                     configuration_secure_material.url, constants.CONFIGURATION_SECURE_VERSION
                 ),

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -1476,7 +1476,7 @@ def generate_find_and_advance_release(
 def generate_check_ci(
         pipeline,
         token,
-        repos_to_check
+        materials_to_check
 ):
     """
     Generates a stage used to check the CI combined test status of a commit.
@@ -1485,8 +1485,7 @@ def generate_check_ci(
     Args:
         pipeline (gomatic.Pipeline):
         token (str): GitHub token used to check CI.
-        repos_to_check (list(list(str, str)):
-            List of materials' paired org/repo names.
+        materials_to_check (list(GomaticGitMaterial): List of materials.
 
     Returns:
         gomatic.Stage
@@ -1498,16 +1497,16 @@ def generate_check_ci(
     )
     stage = pipeline.ensure_stage(constants.CHECK_CI_STAGE_NAME)
     # Add a separate checking job for each org/repo.
-    for org, repo in repos_to_check:
-        repo_underscore = repo.replace('-', '_')
+    for material in materials_to_check:
+        repo_underscore = material.repo.replace('-', '_')
         job = stage.ensure_job(constants.CHECK_CI_JOB_NAME + '_' + repo_underscore)
         tasks.generate_package_install(job, 'tubular')
 
         cmd_args = [
             '--token', '$GIT_TOKEN',
-            '--org', org,
-            '--repo', repo,
-            '--commit_hash', '$GO_REVISION_{}'.format(repo_underscore.upper())
+            '--org', material.org,
+            '--repo', material.repo,
+            '--commit_hash', material.envvar_bash
         ]
         job.add_task(tasks.tubular_task(
             'check_pr_tests_status.py',

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -309,9 +309,21 @@ def generate_launch_instance(
 
     Args:
         job (gomatic.job.Job): the gomatic job which to add the launch instance task
-        runif (str): one of ['passed', 'failed', 'any'] Default: passed
+        aws_access_key_id (str): Access key used to connect to AWS.
+        aws_secret_access_key (str): Secret key used to connect to AWS.
+        ec2_vpc_subnet_id (str): EC2 VPC subnet ID
+        ec2_security_group_id (str): EC2 security group ID
+        ec2_instance_profile_name (str): Instance profile to use to launch the AMI
+        base_ami_id (str): AMI to use when launching instance.
+        ec2_region (str): EC2 region, i.e. us-east-1
+        ec2_instance_type (str): EC2 instance type to launch
+        ec2_timeout (int): Time in seconds to wait for an EC2 instance to be available
+        ec2_ebs_volume_size (int): Size in GB for the root volume
         variable_override_path (str): The path to an already-retrieved yaml file specifying
             variable overrides to use when launching the instance.
+        hipchat_token (str): Auth token to use in posting to HipChat
+        hipchat_room (str): HipChat room where posting is sent
+        runif (str): one of ['passed', 'failed', 'any'] Default: passed
 
     Returns:
         The newly created task (gomatic.gocd.tasks.ExecTask)

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -1443,7 +1443,9 @@ def generate_tag_commit(job,
 def generate_check_pr_tests(job,
                             org,
                             repo,
-                            input_file,
+                            input_file=None,
+                            pr_number=None,
+                            commit_sha=None,
                             runif='passed'):
     """
     Assumptions:
@@ -1463,9 +1465,16 @@ def generate_check_pr_tests(job,
     cmd_args = [
         '--org', org,
         '--repo', repo,
-        '--input_file ../{}/{}'.format(constants.ARTIFACT_PATH, input_file),
         '--token $GIT_TOKEN',
     ]
+    if input_file:
+        cmd_args.extend(
+            ('--input_file', '../{}/{}'.format(constants.ARTIFACT_PATH, input_file))
+        )
+    if pr_number:
+        cmd_args.extend(('--pr_number', pr_number))
+    if commit_sha:
+        cmd_args.extend(('--commit_hash', commit_sha))
     return job.add_task(tubular_task(
         'check_pr_tests_status.py',
         cmd_args,
@@ -1486,7 +1495,9 @@ def generate_poll_pr_tests(job,
         job (gomatic.Job): the Job to attach this stage to.
         org (str): Name of the github organization that holds the repository (e.g. edx)
         repo (str): Name of repository (e.g edx-platform)
-        input_file (str): Name of YAML file containing PR id.
+        input_file (str): Name of YAML file containing PR number.
+        pr_number (int): PR number whose tests should be checked.
+        commit_sha (str): Commit SHA whose test should be checked.
         runif (str): one of ['passed', 'failed', 'any'] Default: passed
 
     Returns:

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -266,7 +266,7 @@ def install_pipelines(configurator, config, env_configs):
     manual_verification.ensure_material(
         PipelineMaterial(
             pipeline_name=stage_md.name,
-            stage_name=constants.DEPLOY_AMI_STAGE_NAME,
+            stage_name=constants.MESSAGE_PR_STAGE_NAME,
             material_name='stage_ami_deploy',
         )
     )

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -259,6 +259,7 @@ def install_pipelines(configurator, config, env_configs):
 
     manual_verification = edxapp.manual_verification(
         edxapp_deploy_group,
+        config
     )
     manual_verification.set_label_template('${stage_ami_deploy}')
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1738

The CI check happens after the armed stage in `manual_verification_edxapp_prod_early_ami_build`

This PR pairs well with:
https://github.com/edx/tubular/pull/164