### PR TITLE
Add the ability to pass env-deploy files at the commandline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -151,6 +151,7 @@ tools:
       - ['stage', *deployment-edx]
       - ['stage', *stage-edx]
       - ['stage', "../gomatic-secure/gocd/vars/tools/environment-deployment-play/stage-edx-edxapp-latest.yml"]
+    env-deploy-variable-file:
       - ['prod-edx', *deployment-edx]
       - ['prod-edx', *prod-edx]
       - ['prod-edx', *prod-edx-edxapp-latest-secure]

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -96,7 +96,7 @@ def release_advancer(edxapp_group, config):
     return pipeline
 
 
-def prerelease_materials(edxapp_group, config, stage_config, prod_edx_config, prod_edge_config):
+def prerelease_materials(edxapp_group, config):
     """
     Generate the prerelease materials pipeline
 
@@ -166,11 +166,12 @@ def prerelease_materials(edxapp_group, config, stage_config, prod_edx_config, pr
 
     # Move the AMI selection jobs here in a single stage.
     stage = pipeline.ensure_stage(constants.BASE_AMI_SELECTION_STAGE_NAME)
-    for edp, localized_config in (
-            (STAGE_EDX_EDXAPP, stage_config),
-            (PROD_EDX_EDXAPP, prod_edx_config),
-            (PROD_EDGE_EDXAPP, prod_edge_config)
+    for edp in (
+            STAGE_EDX_EDXAPP,
+            PROD_EDX_EDXAPP,
+            PROD_EDGE_EDXAPP,
     ):
+        localized_config = config[edp]
         job = stage.ensure_job(constants.BASE_AMI_SELECTION_EDP_JOB_NAME(edp))
         tasks.generate_package_install(job, 'tubular')
         tasks.generate_base_ami_selection(

--- a/edxpipelines/patterns/pipelines.py
+++ b/edxpipelines/patterns/pipelines.py
@@ -281,7 +281,6 @@ def generate_basic_multistage_pipeline(
 def generate_service_deployment_pipelines(
         configurator,
         config,
-        env_configs,
         base_edp,
         partial_app_material,
         has_migrations=True,
@@ -377,7 +376,6 @@ def generate_service_deployment_pipelines(
     ]
 
     for edp, build_pipeline, deploy_pipeline in edp_pipeline_map:
-        env_config = env_configs[edp.environment]
         configuration_material = materials.CONFIGURATION(
             branch='-'.join(['loadtest', edp.play]) if edp == loadtest_edp else 'master'
         )
@@ -426,7 +424,7 @@ def generate_service_deployment_pipelines(
             configuration_secure_material,
             configuration_internal_material,
             constants.PLAYBOOK_PATH_TPL(edp),
-            env_config,
+            config[edp],
             version_tags={
                 edp.play: (app_material.url, app_version_var),
                 'configuration': (configuration_material.url, configuration_material.envvar_bash),
@@ -457,7 +455,7 @@ def generate_service_deployment_pipelines(
             deploy_stage,
             ami_artifact_location,
             edp,
-            env_config,
+            config[edp],
             has_migrations=has_migrations
         )
 
@@ -497,8 +495,8 @@ def generate_service_deployment_pipelines(
                 edp.play,
                 '/edx/app/{}'.format(edp.play),
                 constants.DB_MIGRATION_USER,
-                env_config['db_migration_pass'],
+                config[edp]['db_migration_pass'],
                 migration_info_location,
                 ami_artifact_location=ami_artifact_location,
-                env_config=env_config,
+                config=config[edp],
             )

--- a/edxpipelines/pipelines/api_build.py
+++ b/edxpipelines/pipelines/api_build.py
@@ -25,7 +25,7 @@ PACKAGE_SOURCE_JOB_NAME = 'package-source'
 API_MANAGER_WORKING_DIR = 'api-manager'
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Install pipelines that can build the edX api-gateway.
     """

--- a/edxpipelines/pipelines/api_deploy.py
+++ b/edxpipelines/pipelines/api_deploy.py
@@ -20,7 +20,7 @@ from edxpipelines import constants
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Install the pipelines that can deploy the edX api-gateway.
     """

--- a/edxpipelines/pipelines/asg_cleanup.py
+++ b/edxpipelines/pipelines/asg_cleanup.py
@@ -16,7 +16,7 @@ from edxpipelines.patterns import stages
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/build_ora2_sandbox.py
+++ b/edxpipelines/pipelines/build_ora2_sandbox.py
@@ -16,7 +16,7 @@ from edxpipelines import constants
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/cd_analyticsapi.py
+++ b/edxpipelines/pipelines/cd_analyticsapi.py
@@ -13,7 +13,7 @@ from edxpipelines.patterns import pipelines
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/cd_credentials.py
+++ b/edxpipelines/pipelines/cd_credentials.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.utils import EDP
 
 
-def install_pipelines(configurator, config, env_configs):
+def install_pipelines(configurator, config):
     """
     Generates pipelines used to deploy the credentials service to stage, loadtest, and prod.
     """
@@ -33,7 +33,7 @@ def install_pipelines(configurator, config, env_configs):
         destination_directory=edp.play
     )
 
-    generate_service_deployment_pipelines(configurator, config, env_configs, edp, partial_app_material)
+    generate_service_deployment_pipelines(configurator, config, edp, partial_app_material)
 
 
 if __name__ == '__main__':

--- a/edxpipelines/pipelines/cd_discovery.py
+++ b/edxpipelines/pipelines/cd_discovery.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.utils import EDP
 
 
-def install_pipelines(configurator, config, env_configs):
+def install_pipelines(configurator, config):
     """
     Generates pipelines used to deploy the discovery service to stage, loadtest, and prod.
     """
@@ -33,7 +33,7 @@ def install_pipelines(configurator, config, env_configs):
         destination_directory=edp.play
     )
 
-    generate_service_deployment_pipelines(configurator, config, env_configs, edp, partial_app_material)
+    generate_service_deployment_pipelines(configurator, config, edp, partial_app_material)
 
 
 if __name__ == '__main__':

--- a/edxpipelines/pipelines/cd_ecommerce.py
+++ b/edxpipelines/pipelines/cd_ecommerce.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.utils import EDP
 
 
-def install_pipelines(configurator, config, env_configs):
+def install_pipelines(configurator, config):
     """
     Generates pipelines used to deploy the ecommerce service to stage, loadtest, and prod.
     """
@@ -33,7 +33,7 @@ def install_pipelines(configurator, config, env_configs):
         destination_directory=edp.play
     )
 
-    generate_service_deployment_pipelines(configurator, config, env_configs, edp, partial_app_material)
+    generate_service_deployment_pipelines(configurator, config, edp, partial_app_material)
 
 
 if __name__ == '__main__':

--- a/edxpipelines/pipelines/cd_ecomworker.py
+++ b/edxpipelines/pipelines/cd_ecomworker.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.utils import EDP
 
 
-def install_pipelines(configurator, config, env_configs):
+def install_pipelines(configurator, config):
     """
     Generates pipelines used to deploy the discovery service to stage, loadtest, and prod.
     """
@@ -36,7 +36,6 @@ def install_pipelines(configurator, config, env_configs):
     generate_service_deployment_pipelines(
         configurator,
         config,
-        env_configs,
         edp,
         partial_app_material,
         has_migrations=False

--- a/edxpipelines/pipelines/cd_edxapp.py
+++ b/edxpipelines/pipelines/cd_edxapp.py
@@ -17,7 +17,7 @@ from edxpipelines import constants
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -24,7 +24,7 @@ from edxpipelines.materials import (
 )
 
 
-def install_pipelines(configurator, config, env_configs):
+def install_pipelines(configurator, config):
     """
     Arguments:
         configurator (GoCdConfigurator)
@@ -71,10 +71,7 @@ def install_pipelines(configurator, config, env_configs):
 
     prerelease_materials = edxapp.prerelease_materials(
         edxapp_group,
-        config,
-        env_configs['stage'],
-        env_configs['prod-edx'],
-        env_configs['prod-edge']
+        config
     )
 
     prerelease_merge_artifact = utils.ArtifactLocation(
@@ -97,7 +94,7 @@ def install_pipelines(configurator, config, env_configs):
                 prerelease_merge_artifact=prerelease_merge_artifact,
             ),
         ],
-        config=env_configs['stage'],
+        config=config[edxapp.STAGE_EDX_EDXAPP],
         pipeline_name="STAGE_edxapp_B",
         ami_artifact=utils.ArtifactLocation(
             prerelease_materials.name,
@@ -122,7 +119,7 @@ def install_pipelines(configurator, config, env_configs):
                 prerelease_merge_artifact=prerelease_merge_artifact,
             ),
         ],
-        config=env_configs['prod-edx'],
+        config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_B",
         ami_artifact=utils.ArtifactLocation(
             prerelease_materials.name,
@@ -147,7 +144,7 @@ def install_pipelines(configurator, config, env_configs):
                 prerelease_merge_artifact=prerelease_merge_artifact,
             ),
         ],
-        config=env_configs['prod-edge'],
+        config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_B",
         ami_artifact=utils.ArtifactLocation(
             prerelease_materials.name,
@@ -208,7 +205,7 @@ def install_pipelines(configurator, config, env_configs):
         post_cleanup_builders=[
             edxapp.generate_e2e_test_stage,
         ],
-        config=env_configs['stage'],
+        config=config[edxapp.STAGE_EDX_EDXAPP],
         pipeline_name="STAGE_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
             stage_b.name,
@@ -242,7 +239,7 @@ def install_pipelines(configurator, config, env_configs):
         [
             edxapp.rollback_database(stage_b, stage_md),
         ],
-        config=env_configs['stage'],
+        config=config[edxapp.STAGE_EDX_EDXAPP],
         pipeline_name="stage_edxapp_Rollback_Migrations",
         ami_artifact=utils.ArtifactLocation(
             stage_b.name,
@@ -313,7 +310,7 @@ def install_pipelines(configurator, config, env_configs):
                 auto_deploy_ami=True,
             )
         ],
-        config=env_configs['prod-edx'],
+        config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
             prod_edx_b.name,
@@ -342,7 +339,7 @@ def install_pipelines(configurator, config, env_configs):
                 auto_deploy_ami=True,
             )
         ],
-        config=env_configs['prod-edge'],
+        config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
             prod_edge_b.name,
@@ -388,7 +385,7 @@ def install_pipelines(configurator, config, env_configs):
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edx_edxapp_Rollback_latest',
         deploy_pipeline=prod_edx_md,
-        config=env_configs['prod-edx'],
+        config=config[edxapp.PROD_EDX_EDXAPP],
         ami_pairs=deployed_ami_pairs,
         stage_deploy_pipeline=stage_md,
         base_ami_artifact=utils.ArtifactLocation(
@@ -403,7 +400,7 @@ def install_pipelines(configurator, config, env_configs):
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edge_edxapp_Rollback_latest',
         deploy_pipeline=prod_edge_md,
-        config=env_configs['prod-edge'],
+        config=config[edxapp.PROD_EDGE_EDXAPP],
         ami_pairs=deployed_ami_pairs,
         stage_deploy_pipeline=stage_md,
         base_ami_artifact=utils.ArtifactLocation(
@@ -452,7 +449,7 @@ def install_pipelines(configurator, config, env_configs):
         [
             edxapp.rollback_database(prod_edx_b, prod_edx_md),
         ],
-        config=env_configs['prod-edx'],
+        config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
             prod_edx_b.name,
@@ -472,7 +469,7 @@ def install_pipelines(configurator, config, env_configs):
         [
             edxapp.rollback_database(prod_edge_b, prod_edge_md),
         ],
-        config=env_configs['prod-edge'],
+        config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
             prod_edge_b.name,

--- a/edxpipelines/pipelines/cd_insights.py
+++ b/edxpipelines/pipelines/cd_insights.py
@@ -14,7 +14,7 @@ from edxpipelines.patterns import pipelines
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/deploy_ami.py
+++ b/edxpipelines/pipelines/deploy_ami.py
@@ -13,7 +13,7 @@ from edxpipelines.patterns import pipelines
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/deploy_gomatic_pipelines.py
+++ b/edxpipelines/pipelines/deploy_gomatic_pipelines.py
@@ -16,7 +16,7 @@ from edxpipelines import constants
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - gocd_username

--- a/edxpipelines/pipelines/deploy_marketing_site.py
+++ b/edxpipelines/pipelines/deploy_marketing_site.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.materials import (TUBULAR, EDX_MKTG, ECOM_SECURE)
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Install pipelines that can deploy the edx-mktg site.
     """

--- a/edxpipelines/pipelines/instance_cleanup.py
+++ b/edxpipelines/pipelines/instance_cleanup.py
@@ -14,14 +14,14 @@ from edxpipelines.patterns import stages
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     - aws_access_key_id
     - aws_secret_access_key
     - edx_deployment
     """
-    for _, env_config in env_configs.items():
+    for env_config in config.by_environments():
         pipeline_name = 'Instance-Cleanup-{}'.format(env_config['edx_deployment'])
         pipeline = configurator.ensure_pipeline_group('Janitors')\
                                .ensure_replacement_of_pipeline(pipeline_name)\

--- a/edxpipelines/pipelines/manual_verification.py
+++ b/edxpipelines/pipelines/manual_verification.py
@@ -17,7 +17,7 @@ from edxpipelines.patterns import tasks
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     materials: A list of dictionaries of the materials used in this pipeline

--- a/edxpipelines/pipelines/rollback_asgs.py
+++ b/edxpipelines/pipelines/rollback_asgs.py
@@ -17,7 +17,7 @@ from edxpipelines.patterns import stages
 from edxpipelines.pipelines.script import pipeline_script
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Variables needed for this pipeline:
     materials: List of dictionaries of the materials used in this pipeline

--- a/edxpipelines/pipelines/rollback_prod_marketing_site.py
+++ b/edxpipelines/pipelines/rollback_prod_marketing_site.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.materials import (TUBULAR, EDX_MKTG, ECOM_SECURE)
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Install pipelines that can rollback the production edx-mktg site.
     """

--- a/edxpipelines/pipelines/rollback_stage_marketing_site.py
+++ b/edxpipelines/pipelines/rollback_stage_marketing_site.py
@@ -17,7 +17,7 @@ from edxpipelines.pipelines.script import pipeline_script
 from edxpipelines.materials import (TUBULAR, EDX_MKTG, ECOM_SECURE)
 
 
-def install_pipelines(configurator, config, env_configs):  # pylint: disable=unused-argument
+def install_pipelines(configurator, config):
     """
     Install pipelines that can rollback the stage edx-mktg site.
     """


### PR DESCRIPTION
This also cleans up how we manage configs, so that now you can have a single config dict that supplies a global view of non-environmental config values, but also gives you environmental config values if you ask using an EDP.