### PR TITLE
Add timeouts to long running jobs.

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -290,6 +290,7 @@ def generate_build_stages(app_repo, edp, theme_url, configuration_secure_repo,
             override_artifacts=[
                 prerelease_merge_artifact,
             ],
+            timeout=60
         )
 
         configuration_secure_version = '$GO_REVISION_{}_SECURE'.format(edp.deployment.upper())
@@ -564,8 +565,10 @@ def generate_e2e_test_stage(pipeline, config):
     jenkins_user_name = config['jenkins_user_name']
 
     jenkins_url = "https://build.testeng.edx.org"
+    jenkins_job_timeout = 60 * 60
 
     e2e_tests = jenkins_stage.ensure_job('edx-e2e-test')
+    e2e_tests.timeout = str(jenkins_job_timeout + 60)
     tasks.generate_package_install(e2e_tests, 'tubular')
     tasks.trigger_jenkins_build(
         e2e_tests,
@@ -573,10 +576,11 @@ def generate_e2e_test_stage(pipeline, config):
         jenkins_user_name,
         'edx-e2e-tests',
         {},
-        timeout=60 * 60,
+        timeout=jenkins_job_timeout,
     )
 
     microsites_tests = jenkins_stage.ensure_job('microsites-staging-tests')
+    microsites_tests.timeout = str(jenkins_job_timeout + 60)
     tasks.generate_package_install(microsites_tests, 'tubular')
     tasks.trigger_jenkins_build(
         microsites_tests,
@@ -585,7 +589,7 @@ def generate_e2e_test_stage(pipeline, config):
         'microsites-staging-tests', {
             'CI_BRANCH': 'kashif/white_label',
         },
-        timeout=60 * 60,
+        timeout=jenkins_job_timeout,
     )
 
 

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -200,6 +200,7 @@ def generate_run_play(pipeline,
                       configuration_secure_dir=constants.PRIVATE_CONFIGURATION_LOCAL_DIR,
                       configuration_internal_dir=constants.INTERNAL_CONFIGURATION_LOCAL_DIR,
                       override_artifacts=None,
+                      timeout=None,
                       **kwargs):
     """
     TODO: This currently runs from the configuration/playbooks/continuous_delivery/ directory. Need to figure out how to
@@ -223,6 +224,7 @@ def generate_run_play(pipeline,
         hipchat_room (str):
         manual_approval (bool):
         configuration_secure_dir (str): The secure config directory to use for this play.
+        timeout (int): GoCD job level inactivity timeout setting.
         **kwargs (dict):
             k,v pairs:
                 k: the name of the option to pass to ansible
@@ -237,6 +239,9 @@ def generate_run_play(pipeline,
 
     # Install the requirements.
     job = stage.ensure_job(constants.RUN_PLAY_JOB_NAME)
+    if timeout:
+        job.timeout = str(timeout)
+
     tasks.generate_package_install(job, 'tubular')
     tasks.generate_requirements_install(job, 'configuration')
     tasks.generate_target_directory(job)
@@ -285,7 +290,7 @@ def generate_create_ami_from_instance(pipeline,
                                       app_repo,
                                       aws_access_key_id,
                                       aws_secret_access_key,
-                                      ami_creation_timeout="3600",
+                                      ami_creation_timeout=3600,
                                       ami_wait='yes',
                                       cache_id='',
                                       artifact_path=constants.ARTIFACT_PATH,

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -399,7 +399,7 @@ def generate_create_ami(
         job, play, deployment, edx_environment,
         app_repo, aws_access_key_id,
         aws_secret_access_key, launch_info_path,
-        ami_creation_timeout='3600', ami_wait='yes', cache_id='',
+        ami_creation_timeout=3600, ami_wait='yes', cache_id='',
         artifact_path=constants.ARTIFACT_PATH, hipchat_token='',
         hipchat_room=constants.HIPCHAT_ROOM,
         runif='passed', version_tags=None,
@@ -423,6 +423,7 @@ def generate_create_ami(
         The newly created task (gomatic.gocd.tasks.ExecTask)
 
     """
+    job.timeout = str(ami_creation_timeout + 60)
     job.ensure_encrypted_environment_variables(
         {
             'AWS_ACCESS_KEY_ID': aws_access_key_id,
@@ -453,7 +454,7 @@ def generate_create_ami(
         ('hipchat_room', hipchat_room),
         ('ami_wait', ami_wait),
         ('no_reboot', 'no'),
-        ('ami_creation_timeout', ami_creation_timeout),
+        ('ami_creation_timeout', str(ami_creation_timeout)),
         ('extra_name_identifier', '$GO_PIPELINE_COUNTER'),
         ('cache_id', cache_id),
     ]
@@ -1549,6 +1550,7 @@ def trigger_jenkins_build(
         jenkins_job_name (str): name of the jenkins job to trigger
         jenkins_param (dict): parameter names and values to pass to the job
     """
+    job.timeout = str(timeout + 60)
     command = [
         '--url', jenkins_url,
         '--user_name', jenkins_user_name,

--- a/edxpipelines/pipelines/build_ora2_sandbox.py
+++ b/edxpipelines/pipelines/build_ora2_sandbox.py
@@ -75,13 +75,15 @@ def install_pipelines(configurator, config):
         'configuration_internal_version': '$CONFIGURATION_INTERNAL_VERSION',
         'basic_auth': 'false'
     }
+    jenkins_timeout = 75 * 60
+    jenkins_create_ora2_sandbox_job.timeout = str(jenkins_timeout + 60)
     tasks.trigger_jenkins_build(
         jenkins_create_ora2_sandbox_job,
         constants.ORA2_JENKINS_URL,
         constants.ORA2_JENKINS_USER_NAME,
         constants.CREATE_ORA2_SANDBOX_JENKINS_JOB_NAME,
         create_ora2_sandbox_jenkins_params,
-        timeout=75 * 60
+        timeout=jenkins_timeout
     )
 
     # Create the Set Ora2 Version stage, job, and task


### PR DESCRIPTION
In conjunction with this I will turn on system wide job timeouts set @15 minutes.  Something to keep in mind is that a job will only timeout if there is no console activity, this isn't a kill if any job runs longer than 15 minutes type of thing.

Timeout docs:
https://docs.gocd.io/16.2.0/configuration/job_timeout.html