### PR TITLE
Refactor upstream artifacts for edxapp

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -449,8 +449,7 @@ def generate_migrate_stages(pipeline, config):
     return pipeline
 
 
-def generate_deploy_stages(
-        pipeline_name_build, ami_pairs, stage_deploy_pipeline_artifact,
+def generate_deploy_stages(ami_pairs, stage_deploy_pipeline_artifact,
         base_ami_artifact, head_ami_artifact,
         auto_deploy_ami=False
 ):
@@ -458,7 +457,6 @@ def generate_deploy_stages(
     Create a builder function that adds deployment stages to a pipeline.
 
     Args:
-        pipeline_name_build (str): name of the pipeline that built the AMI
         ami_pairs (list<tuple>): A list of tuples. The first item in the tuple should be Artifact location of the
             base_ami ID that was running before deployment and the ArtifactLocation of the newly deployed AMI ID
             e.g. (ArtifactLocation
@@ -496,19 +494,13 @@ def generate_deploy_stages(
             github_token
             edx_environment
         """
-        built_ami_file_location = utils.ArtifactLocation(
-            pipeline_name_build,
-            constants.BUILD_AMI_STAGE_NAME,
-            constants.BUILD_AMI_JOB_NAME,
-            constants.BUILD_AMI_FILENAME,
-        )
         stages.generate_deploy_ami(
             pipeline,
             config['asgard_api_endpoints'],
             config['asgard_token'],
             config['aws_access_key_id'],
             config['aws_secret_access_key'],
-            built_ami_file_location,
+            head_ami_artifact,
             manual_approval=not auto_deploy_ami
         )
 

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -474,7 +474,7 @@ def generate_deploy_stages(ami_pairs,
                      is_dir=False
                     )
                  )
-        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation):
+        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation): The stage deploy ArtifactLocation
         base_ami_artifact (edxpipelines.utils.ArtifactLocation): Location of the Base AMI selection artifact.
         head_ami_artifact (edxpipelines.utils.ArtifactLocation): Location of the Head AMI selection artifact.
         auto_deploy_ami (bool): should this pipeline automatically deploy the AMI
@@ -686,7 +686,8 @@ def rollback_asgs(
                      is_dir=False
                     )
                  )
-        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation): The edxapp staging deployment pipeline
+        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation): The edxapp staging deployment
+            pipeline artifact
         base_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the base AMI selection
         head_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the head AMI selection
 

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -657,7 +657,7 @@ def generate_e2e_test_stage(pipeline, config):
 
 def rollback_asgs(
         edxapp_deploy_group, pipeline_name,
-        deploy_pipeline, config,
+        config,
         ami_pairs, stage_deploy_pipeline_artifact, base_ami_artifact,
         head_ami_artifact,
 ):
@@ -665,7 +665,6 @@ def rollback_asgs(
     Arguments:
         edxapp_deploy_group (gomatic.PipelineGroup): The group in which to create this pipeline
         pipeline_name (str): The name of this pipeline
-        deploy_pipeline (gomatic.Pipeline): The pipeline to retrieve the ami_deploy_info.yml artifact from
         config (dict): the configuraiton dictionary
         ami_pairs (list<tuple>): A list of tuples. The first item in the tuple should be Artifact location of the
             base_ami ID that was running before deployment and the ArtifactLocation of the newly deployed AMI ID
@@ -704,13 +703,6 @@ def rollback_asgs(
     ):
         pipeline.ensure_material(material())
 
-    # Specify the artifact that will be fetched containing the previous deployment information.
-    deploy_file_location = utils.ArtifactLocation(
-        deploy_pipeline.name,
-        constants.DEPLOY_AMI_STAGE_NAME,
-        constants.DEPLOY_AMI_JOB_NAME,
-        constants.DEPLOY_AMI_OUT_FILENAME,
-    )
 
     # Create the armed stage as this pipeline needs to auto-execute
     stages.generate_armed_stage(pipeline, constants.ARMED_JOB_NAME)
@@ -724,7 +716,7 @@ def rollback_asgs(
         config['aws_secret_access_key'],
         config['hipchat_token'],
         constants.HIPCHAT_ROOM,
-        deploy_file_location,
+        base_ami_artifact,
     )
     # Since we only want this stage to rollback via manual approval, ensure that it is set on this stage.
     rollback_stage.set_has_manual_approval()

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -6,7 +6,7 @@ Gomatic patterns for building the edxapp pipeline.
 
 import sys
 from os import path
-from gomatic import ExecTask, PipelineMaterial, FetchArtifactFile
+from gomatic import ExecTask, FetchArtifactFile
 
 # Used to import edxpipelines files - since the module is not installed.
 sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
@@ -449,10 +449,11 @@ def generate_migrate_stages(pipeline, config):
     return pipeline
 
 
-def generate_deploy_stages(ami_pairs, stage_deploy_pipeline_artifact,
-        base_ami_artifact, head_ami_artifact,
-        auto_deploy_ami=False
-):
+def generate_deploy_stages(ami_pairs,
+                           stage_deploy_pipeline_artifact,
+                           base_ami_artifact,
+                           head_ami_artifact,
+                           auto_deploy_ami=False):
     """
     Create a builder function that adds deployment stages to a pipeline.
 
@@ -473,7 +474,7 @@ def generate_deploy_stages(ami_pairs, stage_deploy_pipeline_artifact,
                      is_dir=False
                     )
                  )
-        stage_deploy_pipeline (gomatic.Pipeline):
+        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation):
         base_ami_artifact (edxpipelines.utils.ArtifactLocation): Location of the Base AMI selection artifact.
         head_ami_artifact (edxpipelines.utils.ArtifactLocation): Location of the Head AMI selection artifact.
         auto_deploy_ami (bool): should this pipeline automatically deploy the AMI
@@ -656,9 +657,12 @@ def generate_e2e_test_stage(pipeline, config):
 
 
 def rollback_asgs(
-        edxapp_deploy_group, pipeline_name,
+        edxapp_deploy_group,
+        pipeline_name,
         config,
-        ami_pairs, stage_deploy_pipeline_artifact, base_ami_artifact,
+        ami_pairs,
+        stage_deploy_pipeline_artifact,
+        base_ami_artifact,
         head_ami_artifact,
 ):
     """
@@ -682,7 +686,7 @@ def rollback_asgs(
                      is_dir=False
                     )
                  )
-        stage_deploy_pipeline (gomatic.Pipeline): The edxapp staging deployment pipeline
+        stage_deploy_pipeline_artifact (edxpipelines.utils.ArtifactLocation): The edxapp staging deployment pipeline
         base_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the base AMI selection
         head_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the head AMI selection
 
@@ -702,7 +706,6 @@ def rollback_asgs(
             EDX_MICROSITE, EDX_INTERNAL, EDGE_INTERNAL,
     ):
         pipeline.ensure_material(material())
-
 
     # Create the armed stage as this pipeline needs to auto-execute
     stages.generate_armed_stage(pipeline, constants.ARMED_JOB_NAME)
@@ -754,7 +757,8 @@ def rollback_database(edp, sub_app_migration_artifacts):
     """
     Arguments:
         edp (EDP): EDP that this builder will roll back
-        migration_artifact (dict<str, edxpipelines.utils.ArtifactLocation>): Pipeline source of the migration information
+        sub_app_migration_artifacts (dict<str, edxpipelines.utils.ArtifactLocation>): Pipeline source of the migration
+            information
 
     Configuration Required:
         aws_access_key_id

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -750,11 +750,11 @@ def armed_stage_builder(pipeline, config):  # pylint: disable=unused-argument
     return pipeline
 
 
-def rollback_database(edp, deploy_pipeline):
+def rollback_database(edp, sub_app_migration_artifacts):
     """
     Arguments:
         edp (EDP): EDP that this builder will roll back
-        deploy_pipeline (gomatic.Pipeline): Pipeline source of the migration information
+        migration_artifact (dict<str, edxpipelines.utils.ArtifactLocation>): Pipeline source of the migration information
 
     Configuration Required:
         aws_access_key_id
@@ -792,26 +792,8 @@ def rollback_database(edp, deploy_pipeline):
             constants.KEY_PEM_FILENAME
         )
 
-        # Specify the upstream deploy pipeline material for this rollback pipeline.
-        # Assumes there's only a single upstream pipeline material for this pipeline.
-        pipeline.ensure_material(
-            PipelineMaterial(
-                pipeline_name=deploy_pipeline.name,
-                stage_name=constants.DEPLOY_AMI_STAGE_NAME,
-                material_name='deploy_pipeline',
-            )
-        )
-
         # Create a a stage for migration rollback.
-        for sub_app in EDXAPP_SUBAPPS:
-            migration_artifact = utils.ArtifactLocation(
-                deploy_pipeline.name,
-                constants.APPLY_MIGRATIONS_STAGE + "_" + sub_app,
-                constants.APPLY_MIGRATIONS_JOB,
-                constants.MIGRATION_OUTPUT_DIR_NAME,
-                is_dir=True
-            )
-
+        for sub_app, migration_artifact in sub_app_migration_artifacts.items():
             stages.generate_rollback_migrations(
                 pipeline,
                 edp,

--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -450,7 +450,7 @@ def generate_migrate_stages(pipeline, config):
 
 
 def generate_deploy_stages(
-        pipeline_name_build, ami_pairs, stage_deploy_pipeline,
+        pipeline_name_build, ami_pairs, stage_deploy_pipeline_artifact,
         base_ami_artifact, head_ami_artifact,
         auto_deploy_ami=False
 ):
@@ -516,7 +516,7 @@ def generate_deploy_stages(
         stages.generate_deployment_messages(
             pipeline=pipeline,
             ami_pairs=ami_pairs,
-            stage_deploy_pipeline=stage_deploy_pipeline,
+            stage_deploy_pipeline_artifact=stage_deploy_pipeline_artifact,
             release_status=constants.ReleaseStatus[config['edx_environment']],
             confluence_user=config['jira_user'],
             confluence_password=config['jira_password'],
@@ -666,7 +666,7 @@ def generate_e2e_test_stage(pipeline, config):
 def rollback_asgs(
         edxapp_deploy_group, pipeline_name,
         deploy_pipeline, config,
-        ami_pairs, stage_deploy_pipeline, base_ami_artifact,
+        ami_pairs, stage_deploy_pipeline_artifact, base_ami_artifact,
         head_ami_artifact,
 ):
     """
@@ -742,7 +742,7 @@ def rollback_asgs(
     stages.generate_deployment_messages(
         pipeline=pipeline,
         ami_pairs=ami_pairs,
-        stage_deploy_pipeline=stage_deploy_pipeline,
+        stage_deploy_pipeline_artifact=stage_deploy_pipeline_artifact,
         base_ami_artifact=base_ami_artifact,
         head_ami_artifact=head_ami_artifact,
         message_tags=[
@@ -766,11 +766,10 @@ def armed_stage_builder(pipeline, config):  # pylint: disable=unused-argument
     return pipeline
 
 
-def rollback_database(edp, build_pipeline, deploy_pipeline):
+def rollback_database(edp, deploy_pipeline):
     """
     Arguments:
         edp (EDP): EDP that this builder will roll back
-        build_pipeline (gomatic.Pipeline): Pipeline source of the launch info (ami-id)
         deploy_pipeline (gomatic.Pipeline): Pipeline source of the migration information
 
     Configuration Required:
@@ -819,14 +818,6 @@ def rollback_database(edp, build_pipeline, deploy_pipeline):
             )
         )
 
-        # We need the build_pipeline upstream so that we can fetch the AMI selection artifact from it
-        pipeline.ensure_material(
-            PipelineMaterial(
-                pipeline_name=build_pipeline.name,
-                stage_name=constants.BUILD_AMI_STAGE_NAME,
-                material_name='select_base_ami',
-            )
-        )
         # Create a a stage for migration rollback.
         for sub_app in EDXAPP_SUBAPPS:
             migration_artifact = utils.ArtifactLocation(

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -786,7 +786,7 @@ def generate_armed_stage(pipeline, stage_name):
 
 
 def generate_deployment_messages(
-        pipeline, ami_pairs, stage_deploy_pipeline,
+        pipeline, ami_pairs, stage_deploy_pipeline_artifact,
         release_status, confluence_user, confluence_password, github_token,
         base_ami_artifact, head_ami_artifact, message_tags,
         manual_approval=False,
@@ -798,10 +798,6 @@ def generate_deployment_messages(
 
     Args:
         pipeline (gomatic.Pipeline): Pipeline to attach this stage
-        prod_build_pipelines (list of gomatic.Pipeline): The build pipelines that produced the AMIs being deployed
-        stage_deploy_pipeline: The pipeline that deployed to staging
-        org (str): Name of the github organization that holds the repository (e.g. edx)
-        repo (str): Name of repository (e.g edx-platform)
         release_status (ReleaseStatus): the current status of the release
         confluence_user (str): The confluence user to create the release page with
         confluence_password (str): The confluence password to create the release page with
@@ -848,12 +844,7 @@ def generate_deployment_messages(
         parent_title = None
         title = None
         space = None
-        input_artifact = ArtifactLocation(
-            stage_deploy_pipeline.name,
-            message_stage.name,
-            constants.PUBLISH_WIKI_JOB_NAME,
-            constants.RELEASE_WIKI_PAGE_ID_FILENAME,
-        )
+        input_artifact = stage_deploy_pipeline_artifact
 
     tasks.generate_release_wiki_page(
         pipeline,

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -798,6 +798,9 @@ def generate_deployment_messages(
 
     Args:
         pipeline (gomatic.Pipeline): Pipeline to attach this stage
+        ami_pairs (tuple): a tuple that consists of the artifact locations for the ami selection and the ami built
+            for all environments.
+        stage_deploy_pipeline_artifact(ArtifactLocation): The artifact location of the stage deploy yaml output.
         release_status (ReleaseStatus): the current status of the release
         confluence_user (str): The confluence user to create the release page with
         confluence_password (str): The confluence password to create the release page with
@@ -951,6 +954,7 @@ def generate_poll_tests_and_merge_pr(pipeline,
         stage (gomatic.Stage): Stage to use when adding tasks -or- None
         job (gomatic.Job): Job to use when adding tasks -or- None
         stage_name (str): Name of the stage
+        job_name (str): Name of the job
         pr_artifact_params (dict): Params to use in creation of artifact-fetching task.
         artifact_filename (str): Filename of the artifact to fetch/read-in.
         org (str): Name of the github organization that holds the repository (e.g. edx)

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -264,7 +264,7 @@ def install_pipelines(configurator, config):
         ],
     )
     rollback_stage_db.ensure_material(PipelineMaterial(stage_md.name, constants.DEPLOY_AMI_STAGE_NAME, constants.APPLY_MIGRATIONS_JOB + "_lms"))
-    rollback_stage_db.set_label_template('${deploy_pipeline}')
+    rollback_stage_db.set_label_template('${stage_ami_deploy}')
 
     manual_verification = edxapp.manual_verification(
         edxapp_deploy_group,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -168,7 +168,7 @@ def install_pipelines(configurator, config):
     deployed_ami_pairs = [
         (
             utils.ArtifactLocation(
-                "/".join([prerelease_materials.name, prod_edx_b.name]),
+                utils.build_artifact_path([prerelease_materials.name, prod_edx_b.name]),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -193,7 +193,7 @@ def install_pipelines(configurator, config):
                 ami_pairs=deployed_ami_pairs,
                 stage_deploy_pipeline_artifact=None,
                 base_ami_artifact=utils.ArtifactLocation(
-                    "/".join([prerelease_materials.name, prod_edx_b.name]),
+                    utils.build_artifact_path([prerelease_materials.name, prod_edx_b.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(STAGE_EDX_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -253,7 +253,7 @@ def install_pipelines(configurator, config):
         config=config[edxapp.STAGE_EDX_EDXAPP],
         pipeline_name="stage_edxapp_Rollback_Migrations",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([stage_b.name, stage_md.name]),
+            utils.build_artifact_path([stage_b.name, stage_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME
@@ -314,13 +314,13 @@ def install_pipelines(configurator, config):
     deployed_ami_pairs_prod = [
         (
             utils.ArtifactLocation(
-                "/".join([prerelease_materials.name, build_pipeline.name, manual_verification.name]),
+                utils.build_artifact_path([prerelease_materials.name, build_pipeline.name, manual_verification.name]),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
             ),
             utils.ArtifactLocation(
-                "/".join([build_pipeline.name, manual_verification.name]),
+                utils.build_artifact_path([build_pipeline.name, manual_verification.name]),
                 constants.BUILD_AMI_STAGE_NAME,
                 constants.BUILD_AMI_JOB_NAME,
                 constants.BUILD_AMI_FILENAME,
@@ -338,19 +338,19 @@ def install_pipelines(configurator, config):
             edxapp.generate_deploy_stages(
                 ami_pairs=deployed_ami_pairs_prod,
                 stage_deploy_pipeline_artifact=utils.ArtifactLocation(
-                    "/".join([stage_md.name, manual_verification.name]),
+                    utils.build_artifact_path([stage_md.name, manual_verification.name]),
                     constants.MESSAGE_PR_STAGE_NAME,
                     constants.PUBLISH_WIKI_JOB_NAME,
                     constants.RELEASE_WIKI_PAGE_ID_FILENAME,
                 ),
                 base_ami_artifact=utils.ArtifactLocation(
-                    "/".join([prerelease_materials.name, prod_edx_b.name, manual_verification.name]),
+                    utils.build_artifact_path([prerelease_materials.name, prod_edx_b.name, manual_verification.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
                 ),
                 head_ami_artifact=utils.ArtifactLocation(
-                    "/".join([prod_edx_b.name, stage_md.name, manual_verification.name]),
+                    utils.build_artifact_path([prod_edx_b.name, stage_md.name, manual_verification.name]),
                     constants.BUILD_AMI_STAGE_NAME,
                     constants.BUILD_AMI_JOB_NAME,
                     constants.BUILD_AMI_FILENAME,
@@ -361,7 +361,7 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edx_b.name, stage_md.name, manual_verification.name]),
+            utils.build_artifact_path([prod_edx_b.name, stage_md.name, manual_verification.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -377,19 +377,19 @@ def install_pipelines(configurator, config):
             edxapp.generate_deploy_stages(
                 ami_pairs=deployed_ami_pairs_prod,
                 stage_deploy_pipeline_artifact=utils.ArtifactLocation(
-                    "/".join([stage_md.name, manual_verification.name]),
+                    utils.build_artifact_path([stage_md.name, manual_verification.name]),
                     constants.MESSAGE_PR_STAGE_NAME,
                     constants.PUBLISH_WIKI_JOB_NAME,
                     constants.RELEASE_WIKI_PAGE_ID_FILENAME,
                 ),
                 base_ami_artifact=utils.ArtifactLocation(
-                    "/".join([prerelease_materials.name, prod_edge_b.name, manual_verification.name]),
+                    utils.build_artifact_path([prerelease_materials.name, prod_edge_b.name, manual_verification.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
                 ),
                 head_ami_artifact=utils.ArtifactLocation(
-                    "/".join([prod_edge_b.name, stage_md.name, manual_verification.name]),
+                    utils.build_artifact_path([prod_edge_b.name, stage_md.name, manual_verification.name]),
                     constants.BUILD_AMI_STAGE_NAME,
                     constants.BUILD_AMI_JOB_NAME,
                     constants.BUILD_AMI_FILENAME,
@@ -400,7 +400,7 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edge_b.name, stage_md.name, manual_verification.name]),
+            utils.build_artifact_path([prod_edge_b.name, stage_md.name, manual_verification.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -428,19 +428,32 @@ def install_pipelines(configurator, config):
     rollback_edx_ami_pair = [
         (
             utils.ArtifactLocation(
-                "/".join([prerelease_materials.name, prod_edx_b.name, stage_md.name, manual_verification.name,
-                          prod_edx_md.name]),
+                utils.build_artifact_path([
+                    prerelease_materials.name,
+                    build_pipeline.name,
+                    stage_md.name,
+                    manual_verification.name,
+                    prod_edx_md.name
+                ]),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
             ),
             utils.ArtifactLocation(
-                "/".join([prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
+                utils.build_artifact_path([
+                    build_pipeline.name,
+                    stage_md.name,
+                    manual_verification.name,
+                    prod_edx_md.name
+                ]),
                 constants.BUILD_AMI_STAGE_NAME,
                 constants.BUILD_AMI_JOB_NAME,
                 constants.BUILD_AMI_FILENAME,
             )
-        )
+        ) for build_pipeline, ami_selection_job_name in [
+            (prod_edx_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP)),
+            (prod_edge_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP))
+        ]
     ]
 
     rollback_edx = edxapp.rollback_asgs(
@@ -449,20 +462,25 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDX_EDXAPP],
         ami_pairs=rollback_edx_ami_pair,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
-            "/".join([stage_md.name, manual_verification.name, prod_edx_md.name]),
+            utils.build_artifact_path([stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.MESSAGE_PR_STAGE_NAME,
             constants.PUBLISH_WIKI_JOB_NAME,
             constants.RELEASE_WIKI_PAGE_ID_FILENAME,
         ),
         base_ami_artifact=utils.ArtifactLocation(
-            "/".join([prerelease_materials.name,
-                      prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
+            utils.build_artifact_path([
+                prerelease_materials.name,
+                prod_edx_b.name,
+                stage_md.name,
+                manual_verification.name,
+                prod_edx_md.name
+            ]),
             constants.BASE_AMI_SELECTION_STAGE_NAME,
             constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP),
             constants.BASE_AMI_OVERRIDE_FILENAME,
         ),
         head_ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
+            utils.build_artifact_path([prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -473,26 +491,32 @@ def install_pipelines(configurator, config):
     rollback_edge_ami_pair = [
         (
             utils.ArtifactLocation(
-                "/".join(
-                    [
-                        prerelease_materials.name,
-                        prod_edge_b.name,
-                        stage_md.name,
-                        manual_verification.name,
-                        prod_edge_md.name
-                    ]
-                ),
+                utils.build_artifact_path([
+                    prerelease_materials.name,
+                    build_pipeline.name,
+                    stage_md.name,
+                    manual_verification.name,
+                    prod_edge_md.name
+                ]),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
             ),
             utils.ArtifactLocation(
-                "/".join([prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
+                utils.build_artifact_path([
+                    build_pipeline.name,
+                    stage_md.name,
+                    manual_verification.name,
+                    prod_edge_md.name
+                ]),
                 constants.BUILD_AMI_STAGE_NAME,
                 constants.BUILD_AMI_JOB_NAME,
                 constants.BUILD_AMI_FILENAME,
             )
-        )
+        ) for build_pipeline, ami_selection_job_name in [
+            (prod_edx_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP)),
+            (prod_edge_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP))
+        ]
     ]
 
     rollback_edge = edxapp.rollback_asgs(
@@ -501,13 +525,13 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDGE_EDXAPP],
         ami_pairs=rollback_edge_ami_pair,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
-            "/".join([stage_md.name, manual_verification.name, prod_edge_md.name]),
+            utils.build_artifact_path([stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.MESSAGE_PR_STAGE_NAME,
             constants.PUBLISH_WIKI_JOB_NAME,
             constants.RELEASE_WIKI_PAGE_ID_FILENAME,
         ),
         base_ami_artifact=utils.ArtifactLocation(
-            "/".join(
+            utils.build_artifact_path(
                 [
                     prerelease_materials.name,
                     prod_edge_b.name,
@@ -521,7 +545,7 @@ def install_pipelines(configurator, config):
             constants.BASE_AMI_OVERRIDE_FILENAME,
         ),
         head_ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
+            utils.build_artifact_path([prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -557,8 +581,12 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edx_b.name, stage_md.name, manual_verification.name,
-                      prod_edx_md.name]),
+            utils.build_artifact_path([
+                prod_edx_b.name,
+                stage_md.name,
+                manual_verification.name,
+                prod_edx_md.name
+            ]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME
@@ -595,8 +623,12 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edge_b.name, stage_md.name, manual_verification.name,
-                      prod_edge_md.name]),
+            utils.build_artifact_path([
+                prod_edge_b.name,
+                stage_md.name,
+                manual_verification.name,
+                prod_edge_md.name
+            ]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME
@@ -616,7 +648,7 @@ def install_pipelines(configurator, config):
     rollback_edge_db.set_label_template('${deploy_pipeline}')
 
     cleanup_prerelease_merge_artifact = utils.ArtifactLocation(
-        "/".join(
+        utils.build_artifact_path(
             [prerelease_materials.name, prod_edge_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
         constants.PRERELEASE_MATERIALS_STAGE_NAME,
         constants.PRERELEASE_MATERIALS_JOB_NAME,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -409,38 +409,57 @@ def install_pipelines(configurator, config):
         ):
             pipeline.ensure_material(material())
 
+    rollback_deployed_ami_pairs = [
+        (
+            utils.ArtifactLocation(
+                "/".join([prerelease_materials.name, build_pipeline.name, stage_md.name, manual_verification.name, deploy_pipeline.name]),
+                constants.BASE_AMI_SELECTION_STAGE_NAME,
+                ami_selection_job_name,
+                constants.BASE_AMI_OVERRIDE_FILENAME,
+            ),
+            utils.ArtifactLocation(
+                "/".join([build_pipeline.name, stage_md.name, manual_verification.name, deploy_pipeline.name]),
+                constants.BUILD_AMI_STAGE_NAME,
+                constants.BUILD_AMI_JOB_NAME,
+                constants.BUILD_AMI_FILENAME,
+            )
+        ) for build_pipeline, deploy_pipeline, ami_selection_job_name in [
+            (prod_edx_b, prod_edx_md, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP)),
+            (prod_edge_b, prod_edge_md, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP))
+        ]
+    ]
+
     rollback_edx = edxapp.rollback_asgs(
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edx_edxapp_Rollback_latest',
-        deploy_pipeline=prod_edx_md,
         config=config[edxapp.PROD_EDX_EDXAPP],
-        ami_pairs=deployed_ami_pairs,
+        ami_pairs=rollback_deployed_ami_pairs,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
-                    "/".join([stage_md.name, manual_verification.name, prod_edx_md.name]),
-                    constants.MESSAGE_PR_STAGE_NAME,
-                    constants.PUBLISH_WIKI_JOB_NAME,
-                    constants.RELEASE_WIKI_PAGE_ID_FILENAME,
-                ),
+            "/".join([stage_md.name, manual_verification.name, prod_edx_md.name]),
+            constants.MESSAGE_PR_STAGE_NAME,
+            constants.PUBLISH_WIKI_JOB_NAME,
+            constants.RELEASE_WIKI_PAGE_ID_FILENAME,
+        ),
         base_ami_artifact=utils.ArtifactLocation(
-            prerelease_materials.name,
+            "/".join([prerelease_materials.name, prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.BASE_AMI_SELECTION_STAGE_NAME,
             constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP),
             constants.BASE_AMI_OVERRIDE_FILENAME,
         ),
         head_ami_artifact=utils.ArtifactLocation(
-            prod_edx_b.name,
+            "/".join([prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
         ),
     )
     rollback_edx.set_label_template('${deploy_ami}')
+
     rollback_edge = edxapp.rollback_asgs(
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edge_edxapp_Rollback_latest',
-        deploy_pipeline=prod_edge_md,
         config=config[edxapp.PROD_EDGE_EDXAPP],
-        ami_pairs=deployed_ami_pairs,
+        ami_pairs=rollback_deployed_ami_pairs,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
             "/".join([stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.MESSAGE_PR_STAGE_NAME,
@@ -448,13 +467,13 @@ def install_pipelines(configurator, config):
             constants.RELEASE_WIKI_PAGE_ID_FILENAME,
         ),
         base_ami_artifact=utils.ArtifactLocation(
-            prerelease_materials.name,
+            "/".join([prerelease_materials.name, prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.BASE_AMI_SELECTION_STAGE_NAME,
             constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP),
             constants.BASE_AMI_OVERRIDE_FILENAME,
         ),
         head_ami_artifact=utils.ArtifactLocation(
-            prod_edge_b.name,
+            "/".join([prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -168,7 +168,7 @@ def install_pipelines(configurator, config):
     deployed_ami_pairs = [
         (
             utils.ArtifactLocation(
-                prerelease_materials.name,
+                "/".join([prerelease_materials.name, prod_edx_b.name]),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -192,9 +192,9 @@ def install_pipelines(configurator, config):
             edxapp.generate_deploy_stages(
                 pipeline_name_build=stage_b.name,
                 ami_pairs=deployed_ami_pairs,
-                stage_deploy_pipeline=None,
+                stage_deploy_pipeline_artifact=None,
                 base_ami_artifact=utils.ArtifactLocation(
-                    prerelease_materials.name,
+                    "/".join([prerelease_materials.name, prod_edx_b.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(STAGE_EDX_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -224,6 +224,10 @@ def install_pipelines(configurator, config):
     stage_md.set_automatic_pipeline_locking()
     stage_md.set_label_template('${STAGE_edxapp_B_build}')
 
+    # TODO
+    # We should consider moving the publish_wiki_job (and perhaps the message_pr_job to their own pipelines, this would
+    # allow the stage M-D pipeline to run independently of the prod_edx_b and prod_edge_b pipelines possibly unblocking
+    # some builds.
     for build_stage in (stage_b, prod_edx_b, prod_edge_b):
         stage_md.ensure_material(
             PipelineMaterial(
@@ -232,18 +236,11 @@ def install_pipelines(configurator, config):
                 material_name="{}_build".format(build_stage.name),
             )
         )
-    stage_md.ensure_material(
-        PipelineMaterial(
-            pipeline_name=prerelease_materials.name,
-            stage_name=constants.BASE_AMI_SELECTION_STAGE_NAME,
-            material_name="prerelease",
-        )
-    )
 
     rollback_stage_db = edxapp.launch_and_terminate_subset_pipeline(
         edxapp_deploy_group,
         [
-            edxapp.rollback_database(edxapp.STAGE_EDX_EDXAPP, stage_b, stage_md),
+            edxapp.rollback_database(edxapp.STAGE_EDX_EDXAPP, stage_md),
         ],
         config=config[edxapp.STAGE_EDX_EDXAPP],
         pipeline_name="stage_edxapp_Rollback_Migrations",
@@ -299,16 +296,41 @@ def install_pipelines(configurator, config):
     # When manually triggered in the pipeline above, the following two pipelines migrate/deploy
     # to the production EDX and EDGE environments.
 
+    deployed_ami_pairs_prod = [
+        (
+            utils.ArtifactLocation(
+                "/".join([prerelease_materials.name, build_pipeline.name, manual_verification.name]),
+                constants.BASE_AMI_SELECTION_STAGE_NAME,
+                ami_selection_job_name,
+                constants.BASE_AMI_OVERRIDE_FILENAME,
+            ),
+            utils.ArtifactLocation(
+                "/".join([build_pipeline.name, manual_verification.name]),
+                constants.BUILD_AMI_STAGE_NAME,
+                constants.BUILD_AMI_JOB_NAME,
+                constants.BUILD_AMI_FILENAME,
+            )
+        ) for build_pipeline, ami_selection_job_name in [
+            (prod_edx_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP)),
+            (prod_edge_b, constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP))
+        ]
+    ]
+
     prod_edx_md = edxapp.launch_and_terminate_subset_pipeline(
         edxapp_deploy_group,
         [
             edxapp.generate_migrate_stages,
             edxapp.generate_deploy_stages(
-                pipeline_name_build=prod_edx_b.name,
-                ami_pairs=deployed_ami_pairs,
-                stage_deploy_pipeline=stage_md,
+                pipeline_name_build="/".join([prod_edx_b.name, manual_verification.name]),
+                ami_pairs=deployed_ami_pairs_prod,
+                stage_deploy_pipeline_artifact=utils.ArtifactLocation(
+                    "/".join([stage_md.name, manual_verification.name]),
+                    constants.MESSAGE_PR_STAGE_NAME,
+                    constants.PUBLISH_WIKI_JOB_NAME,
+                    constants.RELEASE_WIKI_PAGE_ID_FILENAME,
+                ),
                 base_ami_artifact=utils.ArtifactLocation(
-                    prerelease_materials.name,
+                    "/".join([prerelease_materials.name, prod_edx_b.name, manual_verification.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -339,11 +361,16 @@ def install_pipelines(configurator, config):
         [
             edxapp.generate_migrate_stages,
             edxapp.generate_deploy_stages(
-                pipeline_name_build=prod_edge_b.name,
-                ami_pairs=deployed_ami_pairs,
-                stage_deploy_pipeline=stage_md,
+                pipeline_name_build="/".join([prod_edge_b.name, manual_verification.name]),
+                ami_pairs=deployed_ami_pairs_prod,
+                stage_deploy_pipeline_artifact=utils.ArtifactLocation(
+                    "/".join([stage_md.name, manual_verification.name]),
+                    constants.MESSAGE_PR_STAGE_NAME,
+                    constants.PUBLISH_WIKI_JOB_NAME,
+                    constants.RELEASE_WIKI_PAGE_ID_FILENAME,
+                ),
                 base_ami_artifact=utils.ArtifactLocation(
-                    prerelease_materials.name,
+                    "/".join([prerelease_materials.name, prod_edge_b.name, manual_verification.name]),
                     constants.BASE_AMI_SELECTION_STAGE_NAME,
                     constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP),
                     constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -360,7 +387,7 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
-            prod_edge_b.name,
+            "/".join([prod_edge_b.name, manual_verification.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -377,20 +404,6 @@ def install_pipelines(configurator, config):
                 material_name="prod_release_gate",
             )
         )
-        for build in (prod_edx_b, prod_edge_b):
-            deploy.ensure_material(
-                PipelineMaterial(build.name, constants.BUILD_AMI_STAGE_NAME, "{}_build".format(build.name))
-            )
-        deploy.ensure_material(
-            PipelineMaterial(stage_md.name, constants.TERMINATE_INSTANCE_STAGE_NAME, "terminate_instance_stage")
-        )
-        deploy.ensure_material(
-            PipelineMaterial(
-                pipeline_name=prerelease_materials.name,
-                stage_name=constants.BASE_AMI_SELECTION_STAGE_NAME,
-                material_name="prerelease",
-            )
-        )
 
     for pipeline in (stage_b, stage_md, prod_edx_b, prod_edx_md, prod_edge_b, prod_edge_md):
         for material in (
@@ -405,7 +418,12 @@ def install_pipelines(configurator, config):
         deploy_pipeline=prod_edx_md,
         config=config[edxapp.PROD_EDX_EDXAPP],
         ami_pairs=deployed_ami_pairs,
-        stage_deploy_pipeline=stage_md,
+        stage_deploy_pipeline_artifact=utils.ArtifactLocation(
+                    "/".join([stage_md.name, manual_verification.name, prod_edx_md.name]),
+                    constants.MESSAGE_PR_STAGE_NAME,
+                    constants.PUBLISH_WIKI_JOB_NAME,
+                    constants.RELEASE_WIKI_PAGE_ID_FILENAME,
+                ),
         base_ami_artifact=utils.ArtifactLocation(
             prerelease_materials.name,
             constants.BASE_AMI_SELECTION_STAGE_NAME,
@@ -426,7 +444,12 @@ def install_pipelines(configurator, config):
         deploy_pipeline=prod_edge_md,
         config=config[edxapp.PROD_EDGE_EDXAPP],
         ami_pairs=deployed_ami_pairs,
-        stage_deploy_pipeline=stage_md,
+        stage_deploy_pipeline_artifact=utils.ArtifactLocation(
+            "/".join([stage_md.name, manual_verification.name, prod_edge_md.name]),
+            constants.MESSAGE_PR_STAGE_NAME,
+            constants.PUBLISH_WIKI_JOB_NAME,
+            constants.RELEASE_WIKI_PAGE_ID_FILENAME,
+        ),
         base_ami_artifact=utils.ArtifactLocation(
             prerelease_materials.name,
             constants.BASE_AMI_SELECTION_STAGE_NAME,
@@ -442,30 +465,6 @@ def install_pipelines(configurator, config):
     )
     rollback_edge.set_label_template('${deploy_ami}')
 
-    for rollback_pipeline in (rollback_edx, rollback_edge):
-        rollback_pipeline.ensure_material(
-            PipelineMaterial(
-                pipeline_name=stage_md.name,
-                stage_name=constants.TERMINATE_INSTANCE_STAGE_NAME,
-                material_name='terminate_instance_stage',
-            )
-        )
-        rollback_pipeline.ensure_material(
-            PipelineMaterial(
-                pipeline_name=prerelease_materials.name,
-                stage_name=constants.BASE_AMI_SELECTION_STAGE_NAME,
-                material_name="prerelease",
-            )
-        )
-        for build in (prod_edx_b, prod_edge_b):
-            rollback_pipeline.ensure_material(
-                PipelineMaterial(
-                    pipeline_name=build.name,
-                    stage_name=constants.BUILD_AMI_STAGE_NAME,
-                    material_name='{}_build_ami'.format(build.name),
-                )
-            )
-
     rollback_edx.ensure_material(
         PipelineMaterial(prod_edx_md.name, constants.DEPLOY_AMI_STAGE_NAME, "deploy_ami")
     )
@@ -477,7 +476,7 @@ def install_pipelines(configurator, config):
     rollback_edx_db = edxapp.launch_and_terminate_subset_pipeline(
         edxapp_deploy_group,
         [
-            edxapp.rollback_database(edxapp.PROD_EDX_EDXAPP, prod_edx_b, prod_edx_md),
+            edxapp.rollback_database(edxapp.PROD_EDX_EDXAPP, prod_edx_md),
         ],
         config=config[edxapp.PROD_EDX_EDXAPP],
         pipeline_name="PROD_edx_edxapp_Rollback_Migrations_latest",
@@ -497,12 +496,12 @@ def install_pipelines(configurator, config):
     rollback_edge_db = edxapp.launch_and_terminate_subset_pipeline(
         edxapp_deploy_group,
         [
-            edxapp.rollback_database(edxapp.PROD_EDGE_EDXAPP, prod_edge_b, prod_edge_md),
+            edxapp.rollback_database(edxapp.PROD_EDGE_EDXAPP, prod_edge_md),
         ],
         config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_Rollback_Migrations_latest",
         ami_artifact=utils.ArtifactLocation(
-            prod_edge_b.name,
+            "/".join([prod_edge_b.name, manual_verification.name, prod_edge_md.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME
@@ -530,13 +529,6 @@ def install_pipelines(configurator, config):
     )
     merge_back.set_label_template('${{deploy_pipeline_{}}}'.format(prod_edx_md.name))
 
-    merge_back.ensure_material(
-        PipelineMaterial(
-            pipeline_name=prerelease_materials.name,
-            stage_name=constants.PRERELEASE_MATERIALS_STAGE_NAME,
-            material_name='prerelease_materials',
-        )
-    )
     # Specify the upstream deploy pipeline materials for this branch-merging pipeline.
     for deploy_pipeline in (prod_edx_md, prod_edge_md):
         merge_back.ensure_material(

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -553,8 +553,6 @@ def install_pipelines(configurator, config):
     )
     rollback_edge.set_label_template('${deploy_ami}')
 
-    # For wiki page updates the rollback pipeline must have
-
     rollback_edx.ensure_material(
         PipelineMaterial(prod_edx_md.name, constants.DEPLOY_AMI_STAGE_NAME, "deploy_ami")
     )

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -190,7 +190,6 @@ def install_pipelines(configurator, config):
         stage_builders=[
             edxapp.generate_migrate_stages,
             edxapp.generate_deploy_stages(
-                pipeline_name_build=stage_b.name,
                 ami_pairs=deployed_ami_pairs,
                 stage_deploy_pipeline_artifact=None,
                 base_ami_artifact=utils.ArtifactLocation(
@@ -321,7 +320,6 @@ def install_pipelines(configurator, config):
         [
             edxapp.generate_migrate_stages,
             edxapp.generate_deploy_stages(
-                pipeline_name_build="/".join([prod_edx_b.name, manual_verification.name]),
                 ami_pairs=deployed_ami_pairs_prod,
                 stage_deploy_pipeline_artifact=utils.ArtifactLocation(
                     "/".join([stage_md.name, manual_verification.name]),
@@ -336,7 +334,7 @@ def install_pipelines(configurator, config):
                     constants.BASE_AMI_OVERRIDE_FILENAME,
                 ),
                 head_ami_artifact=utils.ArtifactLocation(
-                    prod_edx_b.name,
+                    "/".join([prod_edx_b.name, stage_md.name, manual_verification.name]),
                     constants.BUILD_AMI_STAGE_NAME,
                     constants.BUILD_AMI_JOB_NAME,
                     constants.BUILD_AMI_FILENAME,
@@ -361,7 +359,6 @@ def install_pipelines(configurator, config):
         [
             edxapp.generate_migrate_stages,
             edxapp.generate_deploy_stages(
-                pipeline_name_build="/".join([prod_edge_b.name, manual_verification.name]),
                 ami_pairs=deployed_ami_pairs_prod,
                 stage_deploy_pipeline_artifact=utils.ArtifactLocation(
                     "/".join([stage_md.name, manual_verification.name]),
@@ -376,7 +373,7 @@ def install_pipelines(configurator, config):
                     constants.BASE_AMI_OVERRIDE_FILENAME,
                 ),
                 head_ami_artifact=utils.ArtifactLocation(
-                    prod_edge_b.name,
+                    "/".join([prod_edge_b.name, stage_md.name, manual_verification.name]),
                     constants.BUILD_AMI_STAGE_NAME,
                     constants.BUILD_AMI_JOB_NAME,
                     constants.BUILD_AMI_FILENAME,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -425,7 +425,7 @@ def install_pipelines(configurator, config):
         ):
             pipeline.ensure_material(material())
 
-    rollback_edx_ami_pairs = [
+    rollback_edx_ami_pair = [
         (
             utils.ArtifactLocation(
                 "/".join([prerelease_materials.name, prod_edx_b.name, stage_md.name, manual_verification.name,
@@ -447,7 +447,7 @@ def install_pipelines(configurator, config):
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edx_edxapp_Rollback_latest',
         config=config[edxapp.PROD_EDX_EDXAPP],
-        ami_pairs=rollback_edx_ami_pairs,
+        ami_pairs=rollback_edx_ami_pair,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
             "/".join([stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.MESSAGE_PR_STAGE_NAME,
@@ -470,7 +470,7 @@ def install_pipelines(configurator, config):
     )
     rollback_edx.set_label_template('${deploy_ami}')
 
-    rollback_edge_ami_pairs = [
+    rollback_edge_ami_pair = [
         (
             utils.ArtifactLocation(
                 "/".join(
@@ -499,7 +499,7 @@ def install_pipelines(configurator, config):
         edxapp_deploy_group=edxapp_deploy_group,
         pipeline_name='PROD_edge_edxapp_Rollback_latest',
         config=config[edxapp.PROD_EDGE_EDXAPP],
-        ami_pairs=rollback_edge_ami_pairs,
+        ami_pairs=rollback_edge_ami_pair,
         stage_deploy_pipeline_artifact=utils.ArtifactLocation(
             "/".join([stage_md.name, manual_verification.name, prod_edge_md.name]),
             constants.MESSAGE_PR_STAGE_NAME,

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -263,7 +263,13 @@ def install_pipelines(configurator, config):
             edxapp.armed_stage_builder,
         ],
     )
-    rollback_stage_db.ensure_material(PipelineMaterial(stage_md.name, constants.DEPLOY_AMI_STAGE_NAME, constants.APPLY_MIGRATIONS_JOB + "_lms"))
+    rollback_stage_db.ensure_material(
+        PipelineMaterial(
+            stage_md.name,
+            constants.APPLY_MIGRATIONS_STAGE + '_lms',
+            'stage_ami_deploy'
+        )
+    )
     rollback_stage_db.set_label_template('${stage_ami_deploy}')
 
     manual_verification = edxapp.manual_verification(
@@ -394,7 +400,7 @@ def install_pipelines(configurator, config):
         config=config[edxapp.PROD_EDGE_EDXAPP],
         pipeline_name="PROD_edge_edxapp_M-D",
         ami_artifact=utils.ArtifactLocation(
-            "/".join([prod_edge_b.name, stage_md.name,  manual_verification.name]),
+            "/".join([prod_edge_b.name, stage_md.name, manual_verification.name]),
             constants.BUILD_AMI_STAGE_NAME,
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
@@ -418,7 +424,6 @@ def install_pipelines(configurator, config):
                 EDX_MICROSITE, EDX_INTERNAL, EDGE_INTERNAL
         ):
             pipeline.ensure_material(material())
-
 
     rollback_edx_ami_pairs = [
         (
@@ -450,7 +455,8 @@ def install_pipelines(configurator, config):
             constants.RELEASE_WIKI_PAGE_ID_FILENAME,
         ),
         base_ami_artifact=utils.ArtifactLocation(
-            "/".join([prerelease_materials.name, prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
+            "/".join([prerelease_materials.name,
+                      prod_edx_b.name, stage_md.name, manual_verification.name, prod_edx_md.name]),
             constants.BASE_AMI_SELECTION_STAGE_NAME,
             constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDX_EDXAPP),
             constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -467,8 +473,15 @@ def install_pipelines(configurator, config):
     rollback_edge_ami_pairs = [
         (
             utils.ArtifactLocation(
-                "/".join([prerelease_materials.name, prod_edge_b.name, stage_md.name, manual_verification.name,
-                          prod_edge_md.name]),
+                "/".join(
+                    [
+                        prerelease_materials.name,
+                        prod_edge_b.name,
+                        stage_md.name,
+                        manual_verification.name,
+                        prod_edge_md.name
+                    ]
+                ),
                 constants.BASE_AMI_SELECTION_STAGE_NAME,
                 ami_selection_job_name,
                 constants.BASE_AMI_OVERRIDE_FILENAME,
@@ -494,7 +507,15 @@ def install_pipelines(configurator, config):
             constants.RELEASE_WIKI_PAGE_ID_FILENAME,
         ),
         base_ami_artifact=utils.ArtifactLocation(
-            "/".join([prerelease_materials.name, prod_edge_b.name, stage_md.name, manual_verification.name, prod_edge_md.name]),
+            "/".join(
+                [
+                    prerelease_materials.name,
+                    prod_edge_b.name,
+                    stage_md.name,
+                    manual_verification.name,
+                    prod_edge_md.name
+                ]
+            ),
             constants.BASE_AMI_SELECTION_STAGE_NAME,
             constants.BASE_AMI_SELECTION_EDP_JOB_NAME(PROD_EDGE_EDXAPP),
             constants.BASE_AMI_OVERRIDE_FILENAME,

--- a/edxpipelines/tests/scripts/test_scripts.py
+++ b/edxpipelines/tests/scripts/test_scripts.py
@@ -189,7 +189,6 @@ def test_upstream_stages_for_artifacts(script_result, script_name):
         pp.pprint(required_artifacts)
         pp.pprint('Available Artifacts:')
         pp.pprint(available_artifacts)
-        pp.pprint('\n\n\n')
         assert required_artifacts <= available_artifacts, "Stages containing artifacts to be fetched aren't upstream"
 
 

--- a/edxpipelines/utils.py
+++ b/edxpipelines/utils.py
@@ -206,3 +206,19 @@ def path_to_artifact(filename, artifact_path=constants.ARTIFACT_PATH):
         str
     """
     return '{}/{}'.format(artifact_path, filename)
+
+
+def build_artifact_path(pipelines):
+    """
+    Constructs a pipeline path from a list of pipelines.
+
+    Args:
+        pipelines (list): the list of pipelines in reverse order from the pipeline they are being used
+
+        given a pipeline like this
+
+    Returns:
+        str
+
+    """
+    return "/".join(pipelines)


### PR DESCRIPTION
This PR is part of the work for [TE-2050](https://openedx.atlassian.net/browse/TE-2050). Many materials for pipelines have been removed in favor of fetching them [via an ancestor in the gocd graph.](https://docs.gocd.io/17.4.0/configuration/managing_dependencies.html) 

This should simplify the value stream map view for edxapp and simplify pipeline triggering (as the user will no longer need to look through multiple PipelineMaterial dependencies to figure out why a pipeline has not fired).

@cpennington something I was unsure about was the passing of the AMI pairs to the wiki page generator on rollback. I am currently only passing the rolled back AMI pair (edge or edx) instead of both. Will the wiki page generator still work correctly with only the rolled back environment info or does it need both edge and edx for each rollback (even if you don't rollback the other corresponding environment?)