### PR TITLE
Feanil/ensure python2

### DIFF
--- a/edxpipelines/patterns/jobs.py
+++ b/edxpipelines/patterns/jobs.py
@@ -72,6 +72,8 @@ def generate_build_ami(stage,
         variable_override_path=path_to_artifact(constants.BASE_AMI_OVERRIDE_FILENAME),
     )
 
+    tasks.generate_ensure_python2(job)
+
     # Run the Ansible play for the service.
     tasks.generate_run_app_playbook(
         job,

--- a/edxpipelines/patterns/stages.py
+++ b/edxpipelines/patterns/stages.py
@@ -145,6 +145,8 @@ def generate_launch_instance(
         ) if base_ami_id_artifact else None,
     )
 
+    tasks.generate_ensure_python2(job)
+
     return stage
 
 

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -374,9 +374,9 @@ def generate_ensure_python2(job, runif="passed"):
     Assumes:
         - The play will be run using the continuous delivery ansible config constants.ANSIBLE_CONTINUOUS_DELIVERY_CONFIG
         - The play will be run from the constants.PUBLIC_CONFIGURATION_DIR directory
-        - A key file for this host in "{constatst.ARTIFACT_PATH}/key.pem"
-        - An ansible inventory file "{constatst.ARTIFACT_PATH}/ansible_inventory"
-        - A launch info file "{constatst.ARTIFACT_PATH}/launch_info.yml"
+        - A key file for this host in "{constants.ARTIFACT_PATH}/key.pem"
+        - An ansible inventory file "{constants.ARTIFACT_PATH}/ansible_inventory"
+        - A launch info file "{constants.ARTIFACT_PATH}/launch_info.yml"
 
 
     Args:


### PR DESCRIPTION
We need python2 installed if we want to build from scratch because otherwise we can't run standard ansible playbooks on a fresh 16.04 image.