### PR TITLE
Added stage to run end-to-end tests

### DIFF
--- a/deploy_pipelines.py
+++ b/deploy_pipelines.py
@@ -43,7 +43,7 @@ def print_success_report(success):
     """
     Print out successful script runs.
     """
-    print "Succesfully run scripts:"
+    print "Successfully ran scripts:"
     for item in success:
         logging.info(pprint.pformat(item))
 

--- a/edxpipelines/constants.py
+++ b/edxpipelines/constants.py
@@ -9,6 +9,7 @@ ARM_PRERELEASE_STAGE = 'arm_prerelease'
 DEPLOY_AMI_STAGE_NAME = 'deploy_ami'
 DEPLOY_AMI_JOB_NAME = 'deploy_ami_job'
 DEPLOY_AMI_JOB_NAME_TPL = '{0.environment}_{0.deployment}'.format
+E2E_TESTS_STAGE_NAME = 'e2e_tests'
 RUN_MIGRATIONS_STAGE_NAME = 'apply_migrations'
 RUN_MIGRATIONS_JOB_NAME = 'apply_migrations_job'
 BUILD_AMI_STAGE_NAME = 'build_ami'

--- a/edxpipelines/patterns/jobs.py
+++ b/edxpipelines/patterns/jobs.py
@@ -388,3 +388,35 @@ def generate_tag_commit(
         commit_sha_variable=head_sha_variable,
         input_file=head_sha_artifact.file_name if head_sha_artifact else None,
     )
+
+
+def generate_run_jenkins_job(stage, config):
+    """
+    Generates a Job that runs a Jenkins job.
+
+    Args:
+        stage (gomatic.Stage): Stage to which the Job will be added.
+        config (dict): Environment-specific secure config.
+
+    Returns:
+        gomatic.Job
+    """
+    job = stage.ensure_job('run_jenkins_job')
+    # FIXME: Remove once https://github.com/gocd-contrib/gomatic/pull/27 is released.
+    # pylint: disable=protected-access
+    job._Job__thing_with_environment_variables.ensure_unencrypted_secure_environment_variables(
+        {
+            'JENKINS_USER_TOKEN': config['jenkins_user_token'],
+            'JENKINS_JOB_TOKEN': config['jenkins_job_token'],
+        }
+    )
+
+    tasks.generate_package_install(job, 'tubular')
+    tasks.trigger_jenkins_build(
+        job,
+        config['jenkins_url'],
+        config['jenkins_username'],
+        config['jenkins_job_name'],
+    )
+
+    return job

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -1398,7 +1398,7 @@ def generate_poll_pr_tests(job,
 
 def trigger_jenkins_build(
         job, jenkins_url, jenkins_user_name, jenkins_job_name,
-        jenkins_params, timeout=30 * 60, custom_error_message=None
+        jenkins_params=None, timeout=30 * 60, custom_error_message=None
 ):
     """
     Generate a GoCD task that triggers a jenkins build and polls for its results.
@@ -1413,10 +1413,11 @@ def trigger_jenkins_build(
         jenkins_url (str): base URL for the jenkins server
         jenkins_user_name (str): username on the jenkins system
         jenkins_job_name (str): name of the jenkins job to trigger
-        jenkins_param (dict): parameter names and values to pass to the job
+        jenkins_params (dict): parameter names and values to pass to the job
         timeout (int): how long to wait for the tests to complete
         custom_error_message (str): Custom error message written to the console on job failure
     """
+    jenkins_params = jenkins_params or {}
     job.timeout = str(timeout + 60)
     command = [
         '--url', jenkins_url,

--- a/edxpipelines/pipelines/cd_ecommerce.py
+++ b/edxpipelines/pipelines/cd_ecommerce.py
@@ -18,7 +18,7 @@ def install_pipelines(configurator, config):
     """
     Generates pipelines used to deploy the ecommerce service to stage, loadtest, and prod.
     """
-    generate_single_deployment_service_pipelines(configurator, config, 'ecommerce')
+    generate_single_deployment_service_pipelines(configurator, config, 'ecommerce', run_e2e_tests_after_deploy=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Service deployment pipelines can now be configured to run
end-to-end/acceptance tests after continuous deployment pipelines deploy
AMIs. This new stage will execute a remote Jenkins job.

This functionality has been enabled for the E-Commerce Service.

LEARNER-509