### PR TITLE
Add troubleshooting help to e2e tests on failure

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -640,6 +640,8 @@ def generate_e2e_test_stage(pipeline, config):
         'edx-e2e-tests',
         {},
         timeout=jenkins_job_timeout,
+        custom_error_message="Need help troubleshooting e2e tests failures? "
+                             "See here: https://openedx.atlassian.net/wiki/display/MBT/What+to+do+when+e2e+tests+fail"
     )
 
     microsites_tests = jenkins_stage.ensure_job('microsites-staging-tests')

--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -1396,7 +1396,7 @@ def generate_poll_pr_tests(job,
 
 def trigger_jenkins_build(
         job, jenkins_url, jenkins_user_name, jenkins_job_name,
-        jenkins_params, timeout=30 * 60
+        jenkins_params, timeout=30 * 60, custom_error_message=None
 ):
     """
     Generate a GoCD task that triggers a jenkins build and polls for its results.
@@ -1412,6 +1412,8 @@ def trigger_jenkins_build(
         jenkins_user_name (str): username on the jenkins system
         jenkins_job_name (str): name of the jenkins job to trigger
         jenkins_param (dict): parameter names and values to pass to the job
+        timeout (int): how long to wait for the tests to complete
+        custom_error_message (str): Custom error message written to the console on job failure
     """
     job.timeout = str(timeout + 60)
     command = [
@@ -1426,10 +1428,18 @@ def trigger_jenkins_build(
         for name, value in sorted(jenkins_params.items())
     )
 
-    return job.add_task(tubular_task(
+    job.add_task(tubular_task(
         'jenkins_trigger_build.py',
         command,
     ))
+
+    if custom_error_message:
+        job.add_task(bash_task(
+            'echo {}'.format(custom_error_message),
+            runif='failed'
+        ))
+
+    return job
 
 
 def generate_message_pull_requests_in_commit_range(


### PR DESCRIPTION
This will output a URL to assist pipeline operators in troubleshooting e2e test failures.