### PR TITLE
Add stage counter to AMI names

### DIFF
--- a/edxpipelines/patterns/tasks/common.py
+++ b/edxpipelines/patterns/tasks/common.py
@@ -471,7 +471,7 @@ def generate_create_ami(
         ('ami_wait', ami_wait),
         ('no_reboot', 'no'),
         ('ami_creation_timeout', str(ami_creation_timeout)),
-        ('extra_name_identifier', '$GO_PIPELINE_COUNTER'),
+        ('extra_name_identifier', 'PIPELINE_COUNTER $GO_PIPELINE_COUNTER -- STAGE_COUNTER $GO_STAGE_COUNTER'),
         ('cache_id', cache_id),
     ]
     if version_tags:


### PR DESCRIPTION
FYI @rlucioni @doctoryes 

This will add the stage counter to the AMI name. This will ensure a unique name for each AMI built if a stage is re-run. 

Prevents AMIs from not being built if there is a duplicate name.