### PR TITLE
edxapp rollback now uses correct deploy artifact

### DIFF
--- a/edxpipelines/patterns/edxapp.py
+++ b/edxpipelines/patterns/edxapp.py
@@ -666,6 +666,7 @@ def rollback_asgs(
         stage_deploy_pipeline_artifact,
         base_ami_artifact,
         head_ami_artifact,
+        deploy_artifact,
 ):
     """
     Arguments:
@@ -692,6 +693,7 @@ def rollback_asgs(
             pipeline artifact
         base_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the base AMI selection
         head_ami_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the head AMI selection
+        deploy_artifact (edxpipelines.utils.ArtifactLocation): ArtifactLocation of the last deployment
 
     Configuration Required:
         tubular_sleep_wait_time
@@ -722,7 +724,7 @@ def rollback_asgs(
         config['aws_secret_access_key'],
         config['hipchat_token'],
         constants.HIPCHAT_ROOM,
-        base_ami_artifact,
+        deploy_artifact,
     )
     # Since we only want this stage to rollback via manual approval, ensure that it is set on this stage.
     rollback_stage.set_has_manual_approval()

--- a/edxpipelines/pipelines/cd_edxapp_latest.py
+++ b/edxpipelines/pipelines/cd_edxapp_latest.py
@@ -485,6 +485,12 @@ def install_pipelines(configurator, config):
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
         ),
+        deploy_artifact=utils.ArtifactLocation(
+            utils.build_artifact_path([prod_edx_md.name]),
+            constants.DEPLOY_AMI_STAGE_NAME,
+            constants.DEPLOY_AMI_JOB_NAME,
+            constants.DEPLOY_AMI_OUT_FILENAME,
+        )
     )
     rollback_edx.set_label_template('${deploy_ami}')
 
@@ -550,6 +556,12 @@ def install_pipelines(configurator, config):
             constants.BUILD_AMI_JOB_NAME,
             constants.BUILD_AMI_FILENAME,
         ),
+        deploy_artifact=utils.ArtifactLocation(
+            utils.build_artifact_path([prod_edge_md.name]),
+            constants.DEPLOY_AMI_STAGE_NAME,
+            constants.DEPLOY_AMI_JOB_NAME,
+            constants.DEPLOY_AMI_OUT_FILENAME,
+        )
     )
     rollback_edge.set_label_template('${deploy_ami}')
 


### PR DESCRIPTION
Adding fred as a reviewer on this as an FYI since he is devops on call this week.

This will repair rollback in edxapp when ASGs still exist. I have another fix forthcoming to deal with the AMI issue.